### PR TITLE
refactor: simplify sound management in PhaserSoundStudioPlugin

### DIFF
--- a/.changeset/long-sheep-own.md
+++ b/.changeset/long-sheep-own.md
@@ -1,0 +1,5 @@
+---
+'phaser-sound-studio': patch
+---
+
+remove sound map list and remove useless add sound. Fix to use cache instead get


### PR DESCRIPTION
## Description

Removed the internal sounds map and adjusted sound playback logic to directly use the Phaser sound manager. This change streamlines sound loading and volume control, enhancing code clarity and maintainability.

## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [ ] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [x] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [x] phaser-sound-studio
- [ ] phaser-toolkit-demo
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Changes

### Changed

- Start using sound.cache instead of sound.get

### Removed

- Remove soundList

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)

## Additional Context

Add any additional context about the PR here.
