### PR TITLE
fix: panel width/height considering container bound/width/height

### DIFF
--- a/.changeset/full-eyes-dress.md
+++ b/.changeset/full-eyes-dress.md
@@ -1,0 +1,5 @@
+---
+'hudini': patch
+---
+
+Fix card width/height using child containers. Now calculate the child component width/height

--- a/packages/hudini/src/components/card/card.ts
+++ b/packages/hudini/src/components/card/card.ts
@@ -1,268 +1,310 @@
 import { GameObjects, Scene } from 'phaser';
 import {
-    Color,
-    PhaserWindPlugin,
-    type ColorKey,
-    type RadiusKey,
-    type SpacingKey,
+  Color,
+  PhaserWindPlugin,
+  type ColorKey,
+  type RadiusKey,
+  type SpacingKey,
 } from 'phaser-wind';
 
 import { getPWFromScene } from '../../utils/get-pw-from-scene';
 
 export type CardParams = {
-    /** The Phaser scene to add the card to */
-    scene: Scene;
-    /** X position of the card */
-    x: number;
-    /** Y position of the card */
-    y: number;
-    /** Background color of the card. Defaults to 'white'. */
-    backgroundColor?: ColorKey | string;
-    /** Border radius in px (number) or a Phaser Wind radius token (string). Defaults to 'md'. */
-    borderRadius?: RadiusKey | number;
-    /** Margin/padding in px (number) or a Phaser Wind spacing token (string). Defaults to '4'. */
-    margin?: SpacingKey | number;
-    /** Child component to be contained within the card */
-    child: GameObjects.GameObject;
+  /** The Phaser scene to add the card to */
+  scene: Scene;
+  /** X position of the card */
+  x: number;
+  /** Y position of the card */
+  y: number;
+  /** Background color of the card. Defaults to 'white'. */
+  backgroundColor?: ColorKey | string;
+  /** Border radius in px (number) or a Phaser Wind radius token (string). Defaults to 'md'. */
+  borderRadius?: RadiusKey | number;
+  /** Margin/padding in px (number) or a Phaser Wind spacing token (string). Defaults to '4'. */
+  margin?: SpacingKey | number;
+  /** Child component to be contained within the card */
+  child: GameObjects.GameObject;
 };
 
 /**
  * A flexible card component that adapts to its child content size
  */
 export class Card extends GameObjects.Container {
-    /** The background graphics of the card */
-    public backgroundGraphics!: GameObjects.Graphics;
-    /** The child component contained within the card */
-    public child!: GameObjects.GameObject;
+  /** The background graphics of the card */
+  public backgroundGraphics!: GameObjects.Graphics;
+  /** The child component contained within the card */
+  public child!: GameObjects.GameObject;
 
-    /** Reference to the PhaserWind plugin */
-    private pw: PhaserWindPlugin<{}>;
-    /** Margin size in pixels */
-    private marginPx!: number;
-    /** Border radius in pixels */
-    private borderRadiusPx!: number;
-    /** Background color value */
-    private backgroundColorValue!: string;
+  /** Reference to the PhaserWind plugin */
+  private pw: PhaserWindPlugin<{}>;
+  /** Margin size in pixels */
+  private marginPx!: number;
+  /** Border radius in pixels */
+  private borderRadiusPx!: number;
+  /** Background color value */
+  private backgroundColorValue!: string;
 
-    /**
-     * Creates a new Card
-     * @param params Configuration parameters for the card
-     */
-    constructor({
-        scene,
-        x,
-        y,
-        backgroundColor = 'white',
-        borderRadius = 'md',
-        margin = '4',
-        child,
-    }: CardParams) {
-        super(scene, x, y);
-        this.pw = getPWFromScene(scene);
+  /**
+   * Creates a new Card
+   * @param params Configuration parameters for the card
+   */
+  constructor({
+    scene,
+    x,
+    y,
+    backgroundColor = 'white',
+    borderRadius = 'md',
+    margin = '4',
+    child,
+  }: CardParams) {
+    super(scene, x, y);
+    this.pw = getPWFromScene(scene);
 
-        // Store values
-        this.marginPx =
-            typeof margin === 'number'
-                ? margin
-                : this.pw.spacing.px(margin ?? ('4' as SpacingKey));
-        this.borderRadiusPx =
-            typeof borderRadius === 'number'
-                ? borderRadius
-                : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
-        this.backgroundColorValue = Color.rgb(backgroundColor as ColorKey);
+    // Store values
+    this.marginPx =
+      typeof margin === 'number'
+        ? margin
+        : this.pw.spacing.px(margin ?? ('4' as SpacingKey));
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
+    this.backgroundColorValue = Color.rgb(backgroundColor as ColorKey);
 
-        // Store child reference
-        this.child = child;
+    // Store child reference
+    this.child = child;
 
-        // Create background and setup container
-        this.createBackgroundGraphics(scene);
-        this.setupContainer();
+    // Create background and setup container
+    this.createBackgroundGraphics(scene);
+    this.setupContainer();
+  }
+
+  /**
+   * Sets the background color of the card
+   * @param color Background color token or string
+   * @returns this for chaining
+   */
+  public setBackgroundColor(color: ColorKey | string): this {
+    this.backgroundColorValue = Color.rgb(color as ColorKey);
+    this.drawBackground();
+    return this;
+  }
+
+  /**
+   * Sets the border radius of the card
+   * @param borderRadius Border radius (number in px or RadiusKey)
+   * @returns this for chaining
+   */
+  public setBorderRadius(borderRadius: RadiusKey | number): this {
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
+    this.drawBackground();
+    return this;
+  }
+
+  /**
+   * Sets the margin/padding of the card
+   * @param margin Margin size (number in px or SpacingKey)
+   * @returns this for chaining
+   */
+  public setMargin(margin: SpacingKey | number): this {
+    this.marginPx =
+      typeof margin === 'number'
+        ? margin
+        : this.pw.spacing.px(margin ?? ('4' as SpacingKey));
+    this.layout();
+    return this;
+  }
+
+  /**
+   * Sets a new child component for the card
+   * @param child New child component
+   * @returns this for chaining
+   */
+  public setChild(child: GameObjects.GameObject): this {
+    // Remove old child
+    this.remove(this.child);
+
+    // Set new child
+    this.child = child;
+
+    // Update layout
+    this.layout();
+
+    return this;
+  }
+
+  /**
+   * Creates the background graphics for the card
+   * @param scene The scene to add the graphics to
+   */
+  private createBackgroundGraphics(scene: Scene): void {
+    this.backgroundGraphics = scene.add.graphics();
+    this.drawBackground();
+  }
+
+  /**
+   * Sets up the container with background and child
+   */
+  private setupContainer(): void {
+    this.add([this.backgroundGraphics, this.child]);
+    this.layout();
+  }
+
+  /**
+   * Updates the layout after property changes
+   */
+  public layout(): void {
+    // Get child bounds using type assertion
+    const childBounds = (
+      this.child as unknown as {
+        getBounds: () => { width: number; height: number };
+      }
+    ).getBounds();
+
+    // Calculate card dimensions with margin
+    const cardWidth = childBounds.width + this.marginPx * 2;
+    const cardHeight = childBounds.height + this.marginPx * 2;
+
+    // Check if child has origin property and get its current origin
+    const childOrigin = this.getChildOrigin();
+
+    // Calculate child position considering its origin
+    const childX = this.calculateChildX(
+      cardWidth,
+      childBounds.width,
+      childOrigin
+    );
+    const childY = this.calculateChildY(
+      cardHeight,
+      childBounds.height,
+      childOrigin
+    );
+
+    // Position child in the center of the card
+    (
+      this.child as unknown as { setPosition: (x: number, y: number) => void }
+    ).setPosition(childX, childY);
+
+    // Redraw background with new dimensions
+    this.drawBackground();
+  }
+
+  /**
+   * Gets the child's origin if it exists
+   * @returns Object with x and y origin values, or null if not available
+   */
+  private getChildOrigin(): { x: number; y: number } | null {
+    // Check if child has origin property
+    if ('originX' in this.child && 'originY' in this.child) {
+      return {
+        x: (this.child as unknown as { originX: number }).originX,
+        y: (this.child as unknown as { originY: number }).originY,
+      };
     }
 
-    /**
-     * Sets the background color of the card
-     * @param color Background color token or string
-     * @returns this for chaining
-     */
-    public setBackgroundColor(color: ColorKey | string): this {
-        this.backgroundColorValue = Color.rgb(color as ColorKey);
-        this.drawBackground();
-        return this;
+    // Check if child has getOrigin method
+    if (
+      typeof (
+        this.child as unknown as { getOrigin: () => { x: number; y: number } }
+      ).getOrigin === 'function'
+    ) {
+      const origin = (
+        this.child as unknown as { getOrigin: () => { x: number; y: number } }
+      ).getOrigin();
+      if (
+        origin &&
+        typeof origin.x === 'number' &&
+        typeof origin.y === 'number'
+      ) {
+        return { x: origin.x, y: origin.y };
+      }
     }
 
-    /**
-     * Sets the border radius of the card
-     * @param borderRadius Border radius (number in px or RadiusKey)
-     * @returns this for chaining
-     */
-    public setBorderRadius(borderRadius: RadiusKey | number): this {
-        this.borderRadiusPx =
-            typeof borderRadius === 'number'
-                ? borderRadius
-                : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
-        this.drawBackground();
-        return this;
+    return null;
+  }
+
+  /**
+   * Calculates the X position for the child considering its origin
+   * @param cardWidth Total width of the card
+   * @param childWidth Width of the child
+   * @param childOrigin Origin of the child (null if not available)
+   * @returns X position for the child
+   */
+  private calculateChildX(
+    cardWidth: number,
+    childWidth: number,
+    childOrigin: { x: number; y: number } | null
+  ): number {
+    if (childOrigin) {
+      // Consider child's origin for centering
+      // If child origin is 0.5 (center), we need to offset by half the child width
+      // If child origin is 0 (left), we need to offset by the full child width
+      const originOffsetX = childWidth * childOrigin.x;
+      return -cardWidth / 2 + this.marginPx + originOffsetX;
+    } else {
+      // Fallback to default centering (assumes child origin is center)
+      return -cardWidth / 2 + this.marginPx;
     }
+  }
 
-    /**
-     * Sets the margin/padding of the card
-     * @param margin Margin size (number in px or SpacingKey)
-     * @returns this for chaining
-     */
-    public setMargin(margin: SpacingKey | number): this {
-        this.marginPx =
-            typeof margin === 'number'
-                ? margin
-                : this.pw.spacing.px(margin ?? ('4' as SpacingKey));
-        this.updateLayout();
-        return this;
+  /**
+   * Calculates the Y position for the child considering its origin
+   * @param cardHeight Total height of the card
+   * @param childHeight Height of the child
+   * @param childOrigin Origin of the child (null if not available)
+   * @returns Y position for the child
+   */
+  private calculateChildY(
+    cardHeight: number,
+    childHeight: number,
+    childOrigin: { x: number; y: number } | null
+  ): number {
+    if (childOrigin) {
+      // Consider child's origin for centering
+      // If child origin is 0.5 (center), we need to offset by half the child height
+      // If child origin is 0 (top), we need to offset by the full child height
+      const originOffsetY = childHeight * childOrigin.y;
+      return -cardHeight / 2 + this.marginPx + originOffsetY;
+    } else {
+      // Fallback to default centering (assumes child origin is center)
+      return -cardHeight / 2 + this.marginPx;
     }
+  }
 
-    /**
-     * Sets a new child component for the card
-     * @param child New child component
-     * @returns this for chaining
-     */
-    public setChild(child: GameObjects.GameObject): this {
-        // Remove old child
-        this.remove(this.child);
+  /**
+   * Draws the background graphics
+   */
+  private drawBackground(): void {
+    // Get child bounds for current dimensions
+    const childBounds = (
+      this.child as unknown as {
+        getBounds: () => { width: number; height: number };
+      }
+    ).getBounds();
+    const width = childBounds.width + this.marginPx * 2;
+    const height = childBounds.height + this.marginPx * 2;
 
-        // Set new child
-        this.child = child;
+    this.backgroundGraphics.clear();
 
-        // Update layout
-        this.updateLayout();
+    // Limit radius to maximum possible for the card dimensions
+    const maxRadius = Math.min(width / 2, height / 2);
+    const effectiveRadius = Math.min(this.borderRadiusPx, maxRadius);
 
-        return this;
-    }
+    // Since Graphics doesn't have setOrigin, we need to calculate the offset manually
+    const bgX = -width / 2;
+    const bgY = -height / 2;
 
-    /**
-     * Creates the background graphics for the card
-     * @param scene The scene to add the graphics to
-     */
-    private createBackgroundGraphics(scene: Scene): void {
-        this.backgroundGraphics = scene.add.graphics();
-        this.drawBackground();
-    }
-
-    /**
-     * Sets up the container with background and child
-     */
-    private setupContainer(): void {
-        this.add([this.backgroundGraphics, this.child]);
-        this.updateLayout();
-    }
-
-    /**
-     * Updates the layout after property changes
-     */
-    private updateLayout(): void {
-        // Get child bounds using type assertion
-        const childBounds = (this.child as unknown as { getBounds: () => { width: number; height: number } }).getBounds();
-
-        // Calculate card dimensions with margin
-        const cardWidth = childBounds.width + this.marginPx * 2;
-        const cardHeight = childBounds.height + this.marginPx * 2;
-
-        // Check if child has origin property and get its current origin
-        const childOrigin = this.getChildOrigin();
-
-        // Calculate child position considering its origin
-        const childX = this.calculateChildX(cardWidth, childBounds.width, childOrigin);
-        const childY = this.calculateChildY(cardHeight, childBounds.height, childOrigin);
-
-        // Position child in the center of the card
-        (this.child as unknown as { setPosition: (x: number, y: number) => void }).setPosition(childX, childY);
-
-        // Redraw background with new dimensions
-        this.drawBackground();
-    }
-
-    /**
-     * Gets the child's origin if it exists
-     * @returns Object with x and y origin values, or null if not available
-     */
-    private getChildOrigin(): { x: number; y: number } | null {
-        // Check if child has origin property
-        if ('originX' in this.child && 'originY' in this.child) {
-            return {
-                x: (this.child as unknown as { originX: number }).originX,
-                y: (this.child as unknown as { originY: number }).originY
-            };
-        }
-
-        // Check if child has getOrigin method
-        if (typeof (this.child as unknown as { getOrigin: () => { x: number; y: number } }).getOrigin === 'function') {
-            const origin = (this.child as unknown as { getOrigin: () => { x: number; y: number } }).getOrigin();
-            if (origin && typeof origin.x === 'number' && typeof origin.y === 'number') {
-                return { x: origin.x, y: origin.y };
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Calculates the X position for the child considering its origin
-     * @param cardWidth Total width of the card
-     * @param childWidth Width of the child
-     * @param childOrigin Origin of the child (null if not available)
-     * @returns X position for the child
-     */
-    private calculateChildX(cardWidth: number, childWidth: number, childOrigin: { x: number; y: number } | null): number {
-        if (childOrigin) {
-            // Consider child's origin for centering
-            // If child origin is 0.5 (center), we need to offset by half the child width
-            // If child origin is 0 (left), we need to offset by the full child width
-            const originOffsetX = childWidth * childOrigin.x;
-            return -cardWidth / 2 + this.marginPx + originOffsetX;
-        } else {
-            // Fallback to default centering (assumes child origin is center)
-            return -cardWidth / 2 + this.marginPx;
-        }
-    }
-
-    /**
-     * Calculates the Y position for the child considering its origin
-     * @param cardHeight Total height of the card
-     * @param childHeight Height of the child
-     * @param childOrigin Origin of the child (null if not available)
-     * @returns Y position for the child
-     */
-    private calculateChildY(cardHeight: number, childHeight: number, childOrigin: { x: number; y: number } | null): number {
-        if (childOrigin) {
-            // Consider child's origin for centering
-            // If child origin is 0.5 (center), we need to offset by half the child height
-            // If child origin is 0 (top), we need to offset by the full child height
-            const originOffsetY = childHeight * childOrigin.y;
-            return -cardHeight / 2 + this.marginPx + originOffsetY;
-        } else {
-            // Fallback to default centering (assumes child origin is center)
-            return -cardHeight / 2 + this.marginPx;
-        }
-    }
-
-    /**
-     * Draws the background graphics
-     */
-    private drawBackground(): void {
-        // Get child bounds for current dimensions
-        const childBounds = (this.child as unknown as { getBounds: () => { width: number; height: number } }).getBounds();
-        const width = childBounds.width + this.marginPx * 2;
-        const height = childBounds.height + this.marginPx * 2;
-
-        this.backgroundGraphics.clear();
-
-        // Limit radius to maximum possible for the card dimensions
-        const maxRadius = Math.min(width / 2, height / 2);
-        const effectiveRadius = Math.min(this.borderRadiusPx, maxRadius);
-
-        // Since Graphics doesn't have setOrigin, we need to calculate the offset manually
-        const bgX = -width / 2;
-        const bgY = -height / 2;
-
-        // Draw background
-        this.backgroundGraphics.fillStyle(Color.hex(this.backgroundColorValue), 1);
-        this.backgroundGraphics.fillRoundedRect(bgX, bgY, width, height, effectiveRadius);
-    }
+    // Draw background
+    this.backgroundGraphics.fillStyle(Color.hex(this.backgroundColorValue), 1);
+    this.backgroundGraphics.fillRoundedRect(
+      bgX,
+      bgY,
+      width,
+      height,
+      effectiveRadius
+    );
+  }
 }

--- a/packages/hudini/src/components/column/column.spec.ts
+++ b/packages/hudini/src/components/column/column.spec.ts
@@ -1,46 +1,7 @@
 /* eslint-disable no-magic-numbers */
 /* eslint-disable max-lines-per-function */
 import { GameObjects, Scene } from 'phaser';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Mock to phaser with type to avoid canvas dependency in runtime
-vi.mock('phaser', () => {
-  class Scene { }
-
-  type Positionable = { setPosition(x: number, y: number): void };
-
-  class Container {
-    public list: unknown[] = [];
-    public x: number;
-    public y: number;
-    public width = 0;
-    public height = 0;
-
-    // scene is accepted but not used in the mock
-    constructor(_scene: Scene, x: number, y: number) {
-      this.x = x;
-      this.y = y;
-    }
-
-    add(child: Positionable | Positionable[]): this {
-      if (Array.isArray(child)) {
-        this.list.push(...child);
-      } else {
-        this.list.push(child);
-      }
-      return this;
-    }
-
-    setSize(width: number, height: number): this {
-      this.width = width;
-      this.height = height;
-      return this;
-    }
-  }
-
-  const GameObjects = { Container } as const;
-  return { GameObjects, Scene };
-});
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Column } from './column';
 

--- a/packages/hudini/src/components/flat-icon-button/flat-icon-button.ts
+++ b/packages/hudini/src/components/flat-icon-button/flat-icon-button.ts
@@ -1,4 +1,8 @@
-import { IconText, type IconKey, type IconStyle } from 'font-awesome-for-phaser';
+import {
+  IconText,
+  type IconKey,
+  type IconStyle,
+} from 'font-awesome-for-phaser';
 import { GameObjects, Scene } from 'phaser';
 import {
   Color,
@@ -64,7 +68,11 @@ export class FlatIconButton extends GameObjects.Container {
     this.pw = getPWFromScene(scene);
 
     this.baseSizePx =
-      typeof size === 'number' ? size : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
+
+    this.updateSize();
 
     this.borderRadiusPx =
       typeof borderRadius === 'number'
@@ -129,10 +137,20 @@ export class FlatIconButton extends GameObjects.Container {
 
   public setButtonSize(size: FontSizeKey | number): this {
     this.baseSizePx =
-      typeof size === 'number' ? size : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
     this.iconText.setFontSize(`${this.baseSizePx}px`);
+
+    this.updateSize();
+
     this.regenerateBackgroundTexture();
     return this;
+  }
+
+  private updateSize(): void {
+    this.width = this.baseSizePx * BUTTON_SCALE;
+    this.height = this.baseSizePx * BUTTON_SCALE;
   }
 
   private createBackgroundSprite(scene: Scene): void {
@@ -173,7 +191,11 @@ export class FlatIconButton extends GameObjects.Container {
     return textureKey;
   }
 
-  private createIconText(scene: Scene, icon: IconKey, iconStyle: IconStyle): void {
+  private createIconText(
+    scene: Scene,
+    icon: IconKey,
+    iconStyle: IconStyle
+  ): void {
     this.iconText = new IconText({
       scene,
       x: 0,
@@ -215,5 +237,33 @@ export class FlatIconButton extends GameObjects.Container {
       });
       onClick?.();
     });
+  }
+
+  /**
+   * Gets the bounds of the flat icon button for layout calculations
+   * @param output Optional rectangle to store the result
+   * @returns Rectangle with the button bounds
+   */
+  public override getBounds(
+    output?: Phaser.Geom.Rectangle
+  ): Phaser.Geom.Rectangle {
+    const width = this.baseSizePx * BUTTON_SCALE;
+    const height = this.baseSizePx * BUTTON_SCALE;
+
+    if (output) {
+      return output.setTo(
+        this.x - width / 2,
+        this.y - height / 2,
+        width,
+        height
+      );
+    }
+
+    return new Phaser.Geom.Rectangle(
+      this.x - width / 2,
+      this.y - height / 2,
+      width,
+      height
+    );
   }
 }

--- a/packages/hudini/src/components/icon-button/icon-button.ts
+++ b/packages/hudini/src/components/icon-button/icon-button.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { IconText, type IconKey } from 'font-awesome-for-phaser';
 import { GameObjects, Scene } from 'phaser';
 import {

--- a/packages/hudini/src/components/icon-button/icon-button.ts
+++ b/packages/hudini/src/components/icon-button/icon-button.ts
@@ -49,7 +49,16 @@ export class IconButton extends GameObjects.Container {
   private sizePx!: number;
   private borderRadiusPx!: number;
 
-  constructor({ scene, x, y, icon, size, color, onClick, borderRadius }: IconButtonParams) {
+  constructor({
+    scene,
+    x,
+    y,
+    icon,
+    size,
+    color,
+    onClick,
+    borderRadius,
+  }: IconButtonParams) {
     super(scene, x, y);
     this.pw = getPWFromScene(scene);
 
@@ -59,6 +68,9 @@ export class IconButton extends GameObjects.Container {
         : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
     const baseColor = color ?? 'gray';
     this.sizePx = sizePx;
+
+    this.updateSize();
+
     this.baseColor = baseColor;
     this.borderRadiusPx =
       typeof borderRadius === 'number'
@@ -100,8 +112,13 @@ export class IconButton extends GameObjects.Container {
 
   public setButtonSize(size: FontSizeKey | number): this {
     this.sizePx =
-      typeof size === 'number' ? size : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? ('md' as FontSizeKey));
     this.iconText.setFontSize(`${this.sizePx}px`);
+
+    this.updateSize();
+
     const shadowTexture = this.createShadowTexture(
       this.scene,
       this.sizePx,
@@ -125,7 +142,12 @@ export class IconButton extends GameObjects.Container {
     baseColor: Omit<ColorKey, 'black' | 'white'>,
     borderRadiusPx: number
   ): void {
-    const shadowTexture = this.createShadowTexture(scene, size, baseColor, borderRadiusPx);
+    const shadowTexture = this.createShadowTexture(
+      scene,
+      size,
+      baseColor,
+      borderRadiusPx
+    );
     this.shadowSprite = scene.add.sprite(1, SHADOW_OFFSET, shadowTexture);
     this.shadowSprite.setOrigin(0.5, 0.5);
   }
@@ -169,13 +191,23 @@ export class IconButton extends GameObjects.Container {
     return textureKey;
   }
 
+  private updateSize(): void {
+    this.width = this.sizePx * BUTTON_SCALE;
+    this.height = this.sizePx * BUTTON_SCALE;
+  }
+
   private createBackgroundSprite(
     scene: Scene,
     size: number,
     baseColor: Omit<ColorKey, 'black' | 'white'>,
     borderRadiusPx: number
   ): void {
-    const backgroundTexture = this.createBackgroundTexture(scene, size, baseColor, borderRadiusPx);
+    const backgroundTexture = this.createBackgroundTexture(
+      scene,
+      size,
+      baseColor,
+      borderRadiusPx
+    );
     this.backgroundSprite = scene.add.sprite(1, 0, backgroundTexture);
     this.backgroundSprite.setOrigin(0.5, 0.5);
   }
@@ -285,5 +317,33 @@ export class IconButton extends GameObjects.Container {
       });
       onClick?.();
     });
+  }
+
+  /**
+   * Gets the bounds of the icon button for layout calculations
+   * @param output Optional rectangle to store the result
+   * @returns Rectangle with the button bounds
+   */
+  public override getBounds(
+    output?: Phaser.Geom.Rectangle
+  ): Phaser.Geom.Rectangle {
+    const width = this.shadowSprite.displayWidth ?? this.shadowSprite.width;
+    const height = this.shadowSprite.displayHeight ?? this.shadowSprite.height;
+
+    if (output) {
+      return output.setTo(
+        this.x - width / 2,
+        this.y - height / 2,
+        width,
+        height
+      );
+    }
+
+    return new Phaser.Geom.Rectangle(
+      this.x - width / 2,
+      this.y - height / 2,
+      width,
+      height
+    );
   }
 }

--- a/packages/hudini/src/components/layout/layout-utils.ts
+++ b/packages/hudini/src/components/layout/layout-utils.ts
@@ -11,7 +11,21 @@ export const getDisplayWidthOf = (child: GameObjects.GameObject): number => {
     width?: number;
     getBounds?: () => { width: number };
   };
-  if (typeof childTyped.displayWidth === 'number') return childTyped.displayWidth;
+  // Check if it's a Container-like object (has list property and width/height)
+  if (child && typeof child === 'object' && 'list' in child && Array.isArray((child as unknown as { list: unknown[] }).list)) {
+    const container = child as unknown as { list: unknown[]; width: number };
+    if (container.width > 0) {
+      return container.width;
+    }
+    let w = 0;
+    for (const sub of container.list) {
+      const size = getDisplayWidthOf(sub as GameObjects.GameObject);
+      w = Math.max(w, size);
+    }
+    return w;
+  }
+  if (typeof childTyped.displayWidth === 'number')
+    return childTyped.displayWidth;
   if (typeof childTyped.width === 'number') return childTyped.width as number;
   const bounds = childTyped.getBounds?.();
   return bounds ? bounds.width : 0;
@@ -24,14 +38,30 @@ export const getDisplayHeightOf = (child: GameObjects.GameObject): number => {
     height?: number;
     getBounds?: () => { height: number };
   };
-  if (typeof childTyped.displayHeight === 'number') return childTyped.displayHeight;
+  // Check if it's a Container-like object (has list property and width/height)
+  if (child && typeof child === 'object' && 'list' in child && Array.isArray((child as unknown as { list: unknown[] }).list)) {
+    const container = child as unknown as { list: unknown[]; height: number };
+    if (container.height > 0) {
+      return container.height;
+    }
+    let h = 0;
+    for (const sub of container.list) {
+      const size = getDisplayHeightOf(sub as GameObjects.GameObject);
+      h = Math.max(h, size);
+    }
+    return h;
+  }
+  if (typeof childTyped.displayHeight === 'number')
+    return childTyped.displayHeight;
   if (typeof childTyped.height === 'number') return childTyped.height as number;
   const bounds = childTyped.getBounds?.();
   return bounds ? bounds.height : 0;
 };
 
 /** Returns normalized origin (0..1) for a game object */
-export const getNormalizedOriginOf = (child: GameObjects.GameObject): { x: number; y: number } => {
+export const getNormalizedOriginOf = (
+  child: GameObjects.GameObject
+): { x: number; y: number } => {
   const width = getDisplayWidthOf(child);
   const height = getDisplayHeightOf(child);
 
@@ -47,10 +77,18 @@ export const getNormalizedOriginOf = (child: GameObjects.GameObject): { x: numbe
   let oy: number | undefined =
     typeof childTyped.originY === 'number' ? childTyped.originY : undefined;
 
-  if (ox === undefined && typeof childTyped.displayOriginX === 'number' && width > 0) {
+  if (
+    ox === undefined &&
+    typeof childTyped.displayOriginX === 'number' &&
+    width > 0
+  ) {
     ox = childTyped.displayOriginX / width;
   }
-  if (oy === undefined && typeof childTyped.displayOriginY === 'number' && height > 0) {
+  if (
+    oy === undefined &&
+    typeof childTyped.displayOriginY === 'number' &&
+    height > 0
+  ) {
     oy = childTyped.displayOriginY / height;
   }
 

--- a/packages/hudini/src/components/row/row.spec.ts
+++ b/packages/hudini/src/components/row/row.spec.ts
@@ -1,45 +1,7 @@
 /* eslint-disable no-magic-numbers */
 /* eslint-disable max-lines-per-function */
 import { GameObjects, Scene } from 'phaser';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Typed mock of 'phaser' to avoid canvas dependency
-vi.mock('phaser', () => {
-  class Scene { }
-
-  type Positionable = { setPosition(x: number, y: number): void };
-
-  class Container {
-    public list: unknown[] = [];
-    public x: number;
-    public y: number;
-    public width = 0;
-    public height = 0;
-
-    constructor(_scene: Scene, x: number, y: number) {
-      this.x = x;
-      this.y = y;
-    }
-
-    add(child: Positionable | Positionable[]): this {
-      if (Array.isArray(child)) {
-        this.list.push(...child);
-      } else {
-        this.list.push(child);
-      }
-      return this;
-    }
-
-    setSize(width: number, height: number): this {
-      this.width = width;
-      this.height = height;
-      return this;
-    }
-  }
-
-  const GameObjects = { Container } as const;
-  return { GameObjects, Scene };
-});
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Row } from './row';
 

--- a/packages/hudini/src/components/row/row.ts
+++ b/packages/hudini/src/components/row/row.ts
@@ -91,9 +91,14 @@ export class Row extends GameObjects.Container {
    * @param relayout Whether to update layout after adding
    * @returns This row instance for chaining
    */
-  public addChild(child: GameObjects.GameObject, relayout: boolean = true): this {
+  public addChild(
+    child: GameObjects.GameObject,
+    relayout: boolean = true
+  ): this {
     this.add(child);
-    if (relayout) this.layout();
+    if (relayout) {
+      this.layout();
+    }
     return this;
   }
 
@@ -103,14 +108,17 @@ export class Row extends GameObjects.Container {
    * @param relayout Whether to update layout after adding
    * @returns This row instance for chaining
    */
-  public addChildren(children: GameObjects.GameObject[], relayout: boolean = true): this {
+  public addChildren(
+    children: GameObjects.GameObject[],
+    relayout: boolean = true
+  ): this {
     if (children.length > 0) this.add(children);
     if (relayout) this.layout();
     return this;
   }
 
-  /** 
-   * Recomputes children's positions and updates this container size 
+  /**
+   * Recomputes children's positions and updates this container size
    */
   public layout(): void {
     const children = this.list as GameObjects.GameObject[];
@@ -120,7 +128,7 @@ export class Row extends GameObjects.Container {
     }
 
     // Measure sizes and origins
-    const entries = children.map((child) => ({
+    const entries = children.map(child => ({
       child,
       width: this.getDisplayWidth(child),
       height: this.getDisplayHeight(child),
@@ -128,10 +136,17 @@ export class Row extends GameObjects.Container {
     }));
 
     const maxHeight = entries.reduce((m, s) => Math.max(m, s.height), 0);
-    const totalWidth = entries.reduce((sum, s) => sum + s.width, 0) + this.gap * (entries.length - 1);
+    const totalWidth =
+      entries.reduce((sum, s) => sum + s.width, 0) +
+      this.gap * (entries.length - 1);
 
     // Determine left of content based on horizontalOrigin
-    const contentLeftX = this.horizontalOrigin === 'left' ? 0 : this.horizontalOrigin === 'center' ? -totalWidth / 2 : -totalWidth;
+    const contentLeftX =
+      this.horizontalOrigin === 'left'
+        ? 0
+        : this.horizontalOrigin === 'center'
+          ? -totalWidth / 2
+          : -totalWidth;
 
     // Walk left to right, aligning considering each child's origin
     let cursorLeftX = contentLeftX;
@@ -152,7 +167,9 @@ export class Row extends GameObjects.Container {
       // Horizontal position so that child's left is at cursorLeftX
       const x = cursorLeftX + origin.x * width;
 
-      (child as unknown as { setPosition: (x: number, y: number) => void }).setPosition(x, y);
+      (
+        child as unknown as { setPosition: (x: number, y: number) => void }
+      ).setPosition(x, y);
 
       cursorLeftX += width + this.gap;
     }
@@ -183,7 +200,10 @@ export class Row extends GameObjects.Container {
    * @param child GameObject to get origin from
    * @returns Object with normalized x,y coordinates of the origin point
    */
-  public getNormalizedOrigin(child: GameObjects.GameObject): { x: number; y: number } {
+  public getNormalizedOrigin(child: GameObjects.GameObject): {
+    x: number;
+    y: number;
+  } {
     return getNormalizedOriginOf(child);
   }
 }

--- a/packages/hudini/src/components/row/row.ts
+++ b/packages/hudini/src/components/row/row.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 /* eslint-disable complexity */
 import { GameObjects, Scene } from 'phaser';
 

--- a/packages/hudini/src/test-setup.ts
+++ b/packages/hudini/src/test-setup.ts
@@ -1,0 +1,40 @@
+// Global mock for Phaser in tests
+import { vi } from 'vitest';
+
+// Mock Phaser globally
+vi.mock('phaser', () => {
+  class Scene { }
+
+  type Positionable = { setPosition(x: number, y: number): void };
+
+  class Container {
+    public list: unknown[] = [];
+    public x: number;
+    public y: number;
+    public width = 0;
+    public height = 0;
+
+    constructor(_scene: Scene, x: number, y: number) {
+      this.x = x;
+      this.y = y;
+    }
+
+    add(child: Positionable | Positionable[]): this {
+      if (Array.isArray(child)) {
+        this.list.push(...child);
+      } else {
+        this.list.push(child);
+      }
+      return this;
+    }
+
+    setSize(width: number, height: number): this {
+      this.width = width;
+      this.height = height;
+      return this;
+    }
+  }
+
+  const GameObjects = { Container } as const;
+  return { GameObjects, Scene };
+});

--- a/packages/hudini/vitest.config.ts
+++ b/packages/hudini/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     exclude: ['node_modules', 'dist', 'build'],
+    setupFiles: ['src/test-setup.ts'],
   },
 });

--- a/packages/phaser-toolkit-demo/src/stories/hudini/hudini.advanced-card-usage.stories.ts
+++ b/packages/phaser-toolkit-demo/src/stories/hudini/hudini.advanced-card-usage.stories.ts
@@ -1,0 +1,156 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+import type { Meta, StoryObj } from '@storybook/html';
+import { loadFont } from 'font-awesome-for-phaser';
+import {
+  Card,
+  Color,
+  createTheme,
+  HUDINI_KEY,
+  HudiniPlugin,
+  IconButton,
+  Row,
+  SceneWithHudini
+} from 'hudini';
+import Phaser from 'phaser';
+
+import { cleanGames, createGame } from '../helpers/create-game';
+import { nextFrames } from '../helpers/next-tick';
+
+const ID = 'hudini-advanced-card-usage';
+
+const meta: Meta = {
+  title: 'HUDini/Advanced Card Usage',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Advanced card usage with nested layout components. Shows how to create a card containing a column with a row of small icon buttons.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+class PreviewScene extends SceneWithHudini {
+  constructor() {
+    super('preview');
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor(Color.rgb('slate-100'));
+
+    this.add
+      .text(300, 50, 'Advanced Card Usage', {
+        fontSize: '24px',
+        color: Color.rgb('slate-800'),
+      })
+      .setOrigin(0.5);
+
+    // Create a row of small icon buttons
+    const buttonRow = new Row({
+      scene: this,
+      x: 0,
+      y: 0,
+      gap: 10,
+      align: 'center',
+      children: [
+        new IconButton({
+          scene: this,
+          x: 0,
+          y: 0,
+          icon: 'house',
+          size: 16,
+          color: 'blue',
+        }),
+        new IconButton({
+          scene: this,
+          x: 0,
+          y: 0,
+          icon: 'users',
+          size: 16,
+          color: 'green',
+        }),
+        new IconButton({
+          scene: this,
+          x: 0,
+          y: 0,
+          icon: 'gear',
+          size: 16,
+          color: 'purple',
+        }),
+        new IconButton({
+          scene: this,
+          x: 0,
+          y: 0,
+          icon: 'heart-circle-check',
+          size: 16,
+          color: 'red',
+        }),
+        new IconButton({
+          scene: this,
+          x: 0,
+          y: 0,
+          icon: 'star-of-david',
+          size: 16,
+          color: 'yellow',
+        })
+      ]
+    });
+
+    // Create a card with the column as content
+    const card = new Card({
+      scene: this,
+      x: 300,
+      y: 200,
+      backgroundColor: Color.rgb('slate-700'),
+      borderRadius: 12,
+      margin: 10,
+      child: buttonRow
+    });
+
+    this.add.existing(card);
+
+    card.layout();
+  }
+}
+
+const ensureFontOnce = async (): Promise<void> => {
+  await loadFont();
+};
+
+export const AdvancedCardUsage: StoryObj = {
+  render: (): HTMLElement => {
+    const root = document.getElementById(ID) ?? document.createElement('div');
+    root.id = ID;
+    return root;
+  },
+  play: async (): Promise<void> => {
+    await ensureFontOnce();
+    await cleanGames();
+    await nextFrames(3);
+
+    createGame(ID, {
+      type: Phaser.AUTO,
+      width: 600,
+      height: 400,
+      backgroundColor: Color.rgb('slate-100'),
+      parent: document.getElementById(ID) as HTMLElement,
+      plugins: {
+        global: [
+          {
+            key: HUDINI_KEY,
+            plugin: HudiniPlugin,
+            start: true,
+            data: {
+              theme: createTheme({}),
+            },
+          },
+        ],
+      },
+      scene: [PreviewScene],
+    });
+  }
+};


### PR DESCRIPTION
## Description

This pull request refactors several UI component classes and utility functions to improve layout consistency, sizing logic, and code readability. The most significant changes include standardizing size updates for buttons, adding public `getBounds` methods for layout calculations, and enhancing utility functions to better handle container objects. These updates make layout calculations more reliable and simplify future maintenance.

**Component layout and sizing improvements:**

* Both `IconButton` and `FlatIconButton` now update their `width` and `height` properties whenever the button size changes, ensuring accurate sizing for layout calculations. (`packages/hudini/src/components/icon-button/icon-button.ts` [[1]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cR71-R73) [[2]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cL103-R121) [[3]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cR194-R210); `packages/hudini/src/components/flat-icon-button/flat-icon-button.ts` [[4]](diffhunk://#diff-e814581968af896645a20ebbb97f6f295e34f1d9a18adad4beabe21a6128590cL67-R75) [[5]](diffhunk://#diff-e814581968af896645a20ebbb97f6f295e34f1d9a18adad4beabe21a6128590cL132-R155) [[6]](diffhunk://#diff-e814581968af896645a20ebbb97f6f295e34f1d9a18adad4beabe21a6128590cL176-R198)
* Public `getBounds` methods have been added to both button components, allowing other layout code to easily retrieve their bounding rectangles for positioning and collision detection. (`packages/hudini/src/components/icon-button/icon-button.ts` [[1]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cR321-R348); `packages/hudini/src/components/flat-icon-button/flat-icon-button.ts` [[2]](diffhunk://#diff-e814581968af896645a20ebbb97f6f295e34f1d9a18adad4beabe21a6128590cR241-R268)

**Utility function enhancements:**

* The `getDisplayWidthOf` and `getDisplayHeightOf` functions in `layout-utils.ts` now properly handle container objects by recursively checking their child elements, leading to more accurate measurements for complex layouts. (`packages/hudini/src/components/layout/layout-utils.ts` [[1]](diffhunk://#diff-88d79c2212e255ecfa0c106c09c018e9d15f7459142565bc30cdc49129a3caaeL14-R28) [[2]](diffhunk://#diff-88d79c2212e255ecfa0c106c09c018e9d15f7459142565bc30cdc49129a3caaeL27-R64)
* The `getNormalizedOriginOf` function was refactored for clarity and to handle more edge cases when computing the origin of game objects. (`packages/hudini/src/components/layout/layout-utils.ts` [packages/hudini/src/components/layout/layout-utils.tsL50-R91](diffhunk://#diff-88d79c2212e255ecfa0c106c09c018e9d15f7459142565bc30cdc49129a3caaeL50-R91))

**Code readability and minor refactoring:**

* Several methods and constructors were reformatted for readability, including parameter lists and multi-line logic, making the codebase easier to maintain and extend. (`packages/hudini/src/components/card/card.ts` [[1]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL117-R117) [[2]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL134-R134) [[3]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL153-R165) [[4]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL171-R189) [[5]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL190-R221) [[6]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL212-R240) [[7]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL232-R264) [[8]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL250-R286) [[9]](diffhunk://#diff-d0bf7cc859d32b00c144d1267ed3b95635ff376544ce965cd9ffd335036e134fL266-R308); `packages/hudini/src/components/icon-button/icon-button.ts` [[10]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cL52-R61) [[11]](diffhunk://#diff-5c763d3cce5e5a006d34b06d986450a890b70fd6e06e7377aa42c13a2771208cL128-R150); `packages/hudini/src/components/flat-icon-button/flat-icon-button.ts` [[12]](diffhunk://#diff-e814581968af896645a20ebbb97f6f295e34f1d9a18adad4beabe21a6128590cL1-R5)

**Test and mock cleanup:**

* Removed custom mocking of Phaser in the `column.spec.ts` test file, likely relying on standard test setup for improved reliability and maintainability. (`packages/hudini/src/components/column/column.spec.ts` [packages/hudini/src/components/column/column.spec.tsL4-R4](diffhunk://#diff-090e962cf1fe1063b6507cceeccf0cf06582e0c3fe13424ff1513b0f078dc190L4-R4))

<img width="452" height="284" alt="image" src="https://github.com/user-attachments/assets/dc3f5f94-1ddf-47bf-b1b5-4052de9c053a" />

## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [x] hudini
- [ ] phaser-sound-studio
- [ ] phaser-toolkit-demo
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Changes

### Added

- Validate width/height in container to row/column

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)

