### PR TITLE
Fix/font awesome loader

### DIFF
--- a/.changeset/olive-meals-run.md
+++ b/.changeset/olive-meals-run.md
@@ -1,0 +1,5 @@
+---
+'font-awesome-for-phaser': patch
+---
+
+fix load in font-awesome-for-phaser

--- a/packages/font-awesome-for-phaser/src/loader/load-font.ts
+++ b/packages/font-awesome-for-phaser/src/loader/load-font.ts
@@ -1,7 +1,17 @@
 import WebFont from 'webfontloader';
 
+const ensureFA7Ready = async (): Promise<void> => {
+  const loads = [
+    document.fonts.load('900 16px "Font Awesome 7 Free"', '\uf005'), // Solid (peso 900)
+    document.fonts.load('400 16px "Font Awesome 7 Free"', '\uf2b9'), // Regular (peso 400)
+    document.fonts.load('400 16px "Font Awesome 7 Brands"', '\uf09b'), // Brands (400)
+  ];
+  await Promise.all(loads);
+  await (document as unknown as { fonts: { ready: Promise<void> } })['fonts'].ready;
+}
+
 export const loadFont = (): Promise<void> => {
-  return new Promise((resolve): void => {
+  return new Promise((resolve, reject): void => {
     WebFont.load({
       custom: {
         families: [
@@ -13,13 +23,17 @@ export const loadFont = (): Promise<void> => {
         ],
         urls: [
           'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css',
-          'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/solid.min.css',
-          'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/regular.min.css',
-          'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/brands.min.css',
         ],
       },
       active: (): void => {
-        resolve();
+        ensureFA7Ready().then(() => {
+          resolve();
+        }).catch(() => {
+          reject();
+        });
+      },
+      inactive: (): void => {
+        reject();
       },
     });
   });

--- a/packages/phaser-toolkit-demo/src/stories/hudini/hudini.advanced-card-usage-column.stories.ts
+++ b/packages/phaser-toolkit-demo/src/stories/hudini/hudini.advanced-card-usage-column.stories.ts
@@ -56,6 +56,7 @@ class PreviewScene extends SceneWithHudini {
       y: 0,
       gap: 10,
       align: 'center',
+      verticalOrigin: 'center',
       children: [
         new IconButton({
           scene: this,


### PR DESCRIPTION
## Description

This pull request improves the reliability of loading Font Awesome 7 fonts in the Phaser integration and makes a minor UI alignment adjustment in the demo scene. The most significant change is the addition of a robust font loading mechanism to ensure that all required font weights and styles are ready before proceeding.

**Font loading improvements:**

* Added a new `ensureFA7Ready` function in `load-font.ts` to explicitly load and wait for all relevant Font Awesome 7 font weights and styles using the `document.fonts.load` API, ensuring fonts are fully ready before resolving.
* Updated the `loadFont` function to use `ensureFA7Ready` in the `active` callback, and added error handling via `reject` in both the `inactive` callback and the `catch` block of the promise chain.
* Removed unnecessary individual CSS URLs for solid, regular, and brands styles from the WebFont loader configuration, relying instead on the main CSS file.

**UI alignment adjustment:**

* Set `verticalOrigin: 'center'` in the advanced card usage column demo to improve vertical alignment of UI elements.

## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [ ] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [x] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [ ] phaser-sound-studio
- [ ] phaser-toolkit-demo
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)
