### PR TITLE
fix: correct getChannelVolume method to return 1 when channel volume …

### DIFF
--- a/.changeset/new-cases-grow.md
+++ b/.changeset/new-cases-grow.md
@@ -1,0 +1,5 @@
+---
+'phaser-sound-studio': patch
+---
+
+fix get channel volume, when 0 returns 1.

--- a/packages/phaser-sound-studio/src/plugin/plugin.ts
+++ b/packages/phaser-sound-studio/src/plugin/plugin.ts
@@ -243,7 +243,7 @@ export class PhaserSoundStudioPlugin<
    * @returns {number} The volume for the channel.
    */
   getChannelVolume(channel: TChannel): number {
-    return this.channelVolumes[channel] || 1;
+    return this.channelVolumes[channel] ?? 1;
   }
 
   /**


### PR DESCRIPTION
## Description

This pull request fixes an issue in the `phaser-sound-studio` plugin where retrieving a channel's volume would incorrectly return `1` when the volume was set to `0`. The logic now correctly distinguishes between `0` and `undefined` values.

Bug fix:

* Updated the `getChannelVolume` method in `plugin.ts` to use the nullish coalescing operator (`??`) instead of the logical OR operator (`||`), so that a channel volume of `0` is returned as expected, rather than defaulting to `1`.

Release notes:

* Added a changeset documenting the patch fix for channel volume handling.

## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation (changes to documentation only)
- [x] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [x] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [x] ⚡ Performance (change that improves performance)
- [x] ✅ Test (adding missing tests or correcting existing tests)
- [x] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [x] phaser-sound-studio
- [ ] phaser-toolkit-demo
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Changes

### Added

-

### Changed

-

### Removed

-

## How to Test

1.
2.
3.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)

## Additional Context

Add any additional context about the PR here.
