### PR TITLE
Feature/add custom url to font awesome for phaser

### DIFF
--- a/.changeset/kind-donkeys-laugh.md
+++ b/.changeset/kind-donkeys-laugh.md
@@ -1,0 +1,5 @@
+---
+'font-awesome-for-phaser': minor
+---
+
+add custom url to use in self-hosted

--- a/packages/font-awesome-for-phaser/README.md
+++ b/packages/font-awesome-for-phaser/README.md
@@ -40,6 +40,14 @@ async function startGame() {
 }
 ```
 
+If you want to use self-hosted fonts, you can pass a URL pointing to your `all.min.css` file:
+
+```ts
+loadFont('/fonts/font-awesome/all.min.css').then(() => {
+  new Game(config);
+})
+```
+
 ## Usage
 
 You can use Font Awesome icons in your Phaser game in two ways:

--- a/packages/font-awesome-for-phaser/src/loader/load-font.ts
+++ b/packages/font-awesome-for-phaser/src/loader/load-font.ts
@@ -10,7 +10,7 @@ const ensureFA7Ready = async (): Promise<void> => {
   await (document as unknown as { fonts: { ready: Promise<void> } })['fonts'].ready;
 }
 
-export const loadFont = (): Promise<void> => {
+export const loadFont = (url?: string): Promise<void> => {
   return new Promise((resolve, reject): void => {
     WebFont.load({
       custom: {
@@ -22,7 +22,7 @@ export const loadFont = (): Promise<void> => {
           'FontAwesome',
         ],
         urls: [
-          'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css',
+          url ?? 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css',
         ],
       },
       active: (): void => {


### PR DESCRIPTION
## Description

This pull request introduces support for using a custom URL for self-hosted Font Awesome CSS files in the `font-awesome-for-phaser` package. This allows developers to load Font Awesome fonts from their own servers rather than relying on the CDN, improving flexibility for deployment and offline use.

**Self-hosted font support:**

* Added an optional `url` parameter to the `loadFont` function in `load-font.ts`, allowing users to specify a custom path to their Font Awesome CSS file. [[1]](diffhunk://#diff-4788e67ad6d1838c563b1f0dc5c357f8fb839647f4fc629c24829c83f4a8e89fL13-R13) [[2]](diffhunk://#diff-4788e67ad6d1838c563b1f0dc5c357f8fb839647f4fc629c24829c83f4a8e89fL25-R25)
* Updated the documentation in `README.md` to show how to use the new `url` parameter for self-hosted fonts.

**Release and changelog:**

* Added a changeset marking this update as a minor release, describing the new custom URL feature for self-hosted fonts.

## Type of Change

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [x] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [ ] phaser-sound-studio
- [ ] phaser-toolkit-demo
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Changes

### Added

- Custom url to load font-awesome in self hosted

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)
