### PR TITLE
Fix/joystick in mouse

### DIFF
--- a/.changeset/silent-cats-cough.md
+++ b/.changeset/silent-cats-cough.md
@@ -1,0 +1,5 @@
+---
+'phaser-virtual-joystick': patch
+---
+
+fix bug when move with mouse

--- a/packages/phaser-virtual-joystick/src/joystick.ts
+++ b/packages/phaser-virtual-joystick/src/joystick.ts
@@ -502,7 +502,7 @@ export class VirtualJoystick extends Phaser.GameObjects.Container {
       return;
     }
 
-    if (!this.touchId || this.touchId !== pointer.id) {
+    if (this.touchId == undefined || this.touchId !== pointer.id) {
       return;
     }
 

--- a/packages/showcase/src/pages/phaser-virtual-joystick/default.astro
+++ b/packages/showcase/src/pages/phaser-virtual-joystick/default.astro
@@ -189,55 +189,44 @@ class GameScene extends Phaser.Scene {
       character.setStrokeStyle(2, 0x312E81);
 
       // Create joystick only on touch devices
-      if (this.sys.game.device.input.touch) {
-        this.joystick = new VirtualJoystick({
-          scene: this,
-          bounds: {
-            topLeft: { x: 0, y: 40 },
-            bottomRight: { x: this.cameras.main.width / 2, y: this.cameras.main.height },
-          },
-          stickIcon: this.add.text(0, 0, '🎮', {
-            fontSize: '24px',
-            color: '#ffffff'
-          }),
-          enableWithoutTouch: true,
-        });
-        this.add.existing(this.joystick);
+      this.joystick = new VirtualJoystick({
+        scene: this,
+        bounds: {
+          topLeft: { x: 0, y: 40 },
+          bottomRight: { x: this.cameras.main.width / 2, y: this.cameras.main.height },
+        },
+        stickIcon: this.add.text(0, 0, '🎮', {
+          fontSize: '24px',
+          color: '#ffffff'
+        }),
+        enableWithoutTouch: true,
+      });
+      this.add.existing(this.joystick);
 
-        // Listen to joystick events
-        this.joystick.on('move', (data) => {
-          this.axesPosition = { x: data.x, y: data.y };
-          if (this.positionText) {
-            this.positionText.setText(`Position: (${data.x.toFixed(2)}, ${data.y.toFixed(2)})`);
-          }
-        });
+      // Listen to joystick events
+      this.joystick.on('move', (data) => {
+        this.axesPosition = { x: data.x, y: data.y };
+        if (this.positionText) {
+          this.positionText.setText(`Position: (${data.x.toFixed(2)}, ${data.y.toFixed(2)})`);
+        }
+      });
 
-        this.joystick.on('press', () => {
-          this.axesPosition = { x: 0, y: 0 };
-          if (this.eventText) {
-            this.eventText.setText('Status: Joystick Pressed');
-            this.eventText.setColor(Color.rgb('green-400'));
-          }
-        });
+      this.joystick.on('press', () => {
+        this.axesPosition = { x: 0, y: 0 };
+        if (this.eventText) {
+          this.eventText.setText('Status: Joystick Pressed');
+          this.eventText.setColor(Color.rgb('green-400'));
+        }
+      });
 
-        this.joystick.on('release', () => {
-          this.axesPosition = { x: 0, y: 0 };
-          if (this.eventText) {
-            this.eventText.setText('Status: Joystick Released');
-            this.eventText.setColor(Color.rgb('red-400'));
-          }
-        });
-      } else {
-        // Show message for non-touch devices
-        this.add
-          .text(centerX, centerY, 'This demo requires a touch device to work properly', {
-            color: Color.rgb('slate-400'),
-            align: 'center',
-            fontSize: FontSize.px('lg'),
-            wordWrap: { width: 500 },
-          })
-          .setOrigin(0.5, 0.5);
-      }
+      this.joystick.on('release', () => {
+        this.axesPosition = { x: 0, y: 0 };
+        if (this.eventText) {
+          this.eventText.setText('Status: Joystick Released');
+          this.eventText.setColor(Color.rgb('red-400'));
+        }
+      });
+
 
       // Add some visual elements to show the joystick area
       const joystickArea = this.add.rectangle(


### PR DESCRIPTION
## Description

This pull request addresses a bug in the `phaser-virtual-joystick` package related to mouse movement and updates the demo to improve usability on non-touch devices. The main focus is on fixing input handling and making the demo accessible on all platforms.

Bug fix and input handling improvements:

* Fixed a bug in `VirtualJoystick` where mouse movement was not handled correctly by updating the check for `touchId` to allow for mouse input as well as touch input.

Demo accessibility and UI changes:

* Removed the restriction that only allowed the joystick to be created on touch devices in the demo scene, making the joystick available on all platforms.
* Removed the message that previously informed non-touch device users that the demo required a touch device, since the joystick is now available on all devices.

Documentation:

* Added a changeset describing the bug fix for mouse movement in the `phaser-virtual-joystick` package.
## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [ ] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [ ] phaser-sound-studio
- [ ] phaser-data-studio
- [ ] showcase
- [x] virtual-joystick
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Changes

### Added

-

### Changed

-

### Removed

-

## How to Test

1.
2.
3.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)
