### PR TITLE
Fix/phaser hooks/fix duplicated event in computed state

### DIFF
--- a/.changeset/tired-steaks-hide.md
+++ b/.changeset/tired-steaks-hide.md
@@ -1,5 +1,0 @@
----
-'phaser-hooks': patch
----
-
-remove deprecated onChange in withPersistentState and fix bug with order of callbacks

--- a/.changeset/tired-steaks-hide.md
+++ b/.changeset/tired-steaks-hide.md
@@ -1,0 +1,5 @@
+---
+'phaser-hooks': patch
+---
+
+remove deprecated onChange in withPersistentState and fix bug with order of callbacks

--- a/.changeset/twenty-pianos-stick.md
+++ b/.changeset/twenty-pianos-stick.md
@@ -1,0 +1,5 @@
+---
+'phaser-hooks': patch
+---
+
+withComputedState could emit duplicate updates when instantiated multiple times or when derived value did not change. Computed states are now memoized by key and only propagate changes when the computed value actually changes.


### PR DESCRIPTION
## Description

Issue: https://github.com/renatocassino/phaser-toolkit/issues/233

This PR fixes an issue where withComputedState could trigger duplicate updates when the same computed hook was instantiated multiple times (for example, when a hook factory is executed in both a Scene and a UI component). Each instantiation previously created a new internal subscription to the source state, which caused multiple set() calls for the same computed value.

The implementation now memoizes computed states by key, ensuring that repeated calls return the same hook instance and preventing duplicate subscriptions.

Additionally, computed updates are now only propagated when the derived value actually changes. This prevents unnecessary change events when the source state updates but the computed result remains the same.

These changes ensure consistent behavior, eliminate duplicate change triggers, and improve performance by avoiding redundant updates.

## Type of Change

- [x] 🐛 Bug fix (change that fixes an issue)
- [ ] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [ ] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [x] phaser-hooks
- [ ] phaser-wind
- [ ] hudini
- [ ] phaser-sound-studio
- [ ] phaser-data-studio
- [ ] showcase
- [ ] virtual-joystick
- [ ] Other (please specify): **\*\***\_\_\_**\*\***

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)
