### PR TITLE
feat: add hook to get phaser-wind instance in project

### DIFF
--- a/.changeset/shiny-clouds-lay.md
+++ b/.changeset/shiny-clouds-lay.md
@@ -1,0 +1,6 @@
+---
+'phaser-wind': minor
+'hudini': minor
+---
+
+Add new way to get phaser-wind and hudini instance and opacity to phaser-wind

--- a/packages/hudini/README.md
+++ b/packages/hudini/README.md
@@ -140,6 +140,63 @@ import { Column, Row, IconButton } from 'hudini';
 
 Check the Storybook for live, interactive examples: [Hudini on Storybook](https://renatocassino.github.io/phaser-toolkit/?path=/story/hudini--index)
 
+## 🎯 Access the plugin from your scene
+
+Use the `withHudini(scene)` accessor to get a fully typed handle to the plugin. It composes with any base scene, doesn't rely on global module augmentation, and infers your theme's tokens at the call site.
+
+```ts
+import Phaser from 'phaser';
+import { withHudini } from 'hudini';
+import type { ThemeType } from './theme'; // your createTheme() result
+
+class MyScene extends Phaser.Scene {
+  create(): void {
+    const hudini = withHudini<ThemeType>(this);
+    const pw = hudini.pw; // phaser-wind API, narrowed to your theme
+
+    this.cameras.main.setBackgroundColor(pw.color.rgb('background'));
+  }
+}
+```
+
+Call `withHudini(this)` inside `create()` / `update()` (after the plugin has mounted). Don't call it in the constructor or `init()` — the plugin isn't attached yet.
+
+### Recommended: wrap it in a project-local helper
+
+Passing `<ThemeType>` on every call gets old. Define a one-line helper once in your project so scenes stay short and the theme type stays in one place:
+
+```ts
+// src/theme.ts (in your project)
+import type { Scene } from 'phaser';
+import { createTheme, withHudini, type CreateTheme } from 'hudini';
+
+export const theme = createTheme({
+  colors: { primary: 'blue-600', danger: 'red-500' },
+  // ...
+} satisfies CreateTheme<any>);
+
+export type ThemeType = typeof theme;
+
+/** Project-local accessor — no need to pass the theme type. */
+export const withHud = (scene: Scene) => withHudini<ThemeType>(scene);
+```
+
+Now every scene is a one-liner:
+
+```ts
+import Phaser from 'phaser';
+import { withHud } from './theme';
+
+class MyScene extends Phaser.Scene {
+  create(): void {
+    const hudini = withHud(this); // fully typed against your theme
+    this.cameras.main.setBackgroundColor(hudini.pw.color.rgb('background'));
+  }
+}
+```
+
+You can name the helper whatever fits your style — `withHud`, `useHud`, `getHud`, `hud`. The lib intentionally doesn't ship an alias, so you own the naming in your codebase.
+
 ## 🧩 Components
 
 ### Column

--- a/packages/hudini/src/scene/index.ts
+++ b/packages/hudini/src/scene/index.ts
@@ -1,1 +1,2 @@
 export * from './scene-with-hudini';
+export * from './with-hudini';

--- a/packages/hudini/src/scene/scene-with-hudini.ts
+++ b/packages/hudini/src/scene/scene-with-hudini.ts
@@ -2,11 +2,34 @@ import { BaseThemeConfig, SceneWithPhaserWind } from 'phaser-wind';
 
 import { HudiniPlugin } from '../plugin/plugin';
 
+/**
+ * @deprecated Use {@link withHudini} instead.
+ *
+ * Forces single inheritance, which conflicts with any user-defined `BaseScene`
+ * or other libraries that ship their own scene base class. It also relies on a
+ * non-null assertion (`hudini!`) that lies to TypeScript about when the plugin
+ * is available — touching `this.hudini` before the plugin mounts throws at
+ * runtime.
+ *
+ * Prefer the `withHudini(scene)` accessor:
+ *
+ * ```ts
+ * import { withHudini } from 'hudini';
+ * import type { ThemeType } from './theme';
+ *
+ * class MyScene extends Phaser.Scene {
+ *   create() {
+ *     const hudini = withHudini<ThemeType>(this);
+ *   }
+ * }
+ * ```
+ *
+ * Kept exported to avoid breaking existing consumers.
+ */
 export abstract class SceneWithHudini<
   T extends BaseThemeConfig = BaseThemeConfig,
 > extends SceneWithPhaserWind<T> {
   /**
-   *
    * @param config The scene key or scene specific configuration settings.
    */
   constructor(config?: string | Phaser.Types.Scenes.SettingsConfig) {

--- a/packages/hudini/src/scene/with-hudini.ts
+++ b/packages/hudini/src/scene/with-hudini.ts
@@ -1,0 +1,39 @@
+import type { Scene } from 'phaser';
+import type { BaseThemeConfig } from 'phaser-wind';
+
+import { HUDINI_KEY, HudiniPlugin } from '../plugin/plugin';
+
+/**
+ * Accessor for the Hudini plugin from within a Phaser scene.
+ *
+ * Preferred over {@link SceneWithHudini} (inheritance) and over module
+ * augmentation of `Phaser.Scene`, because it:
+ * - Composes with any existing base scene (no forced inheritance).
+ * - Keeps the theme type explicit at the call site (no silent `any`).
+ * - Doesn't rely on non-null assertions that lie about lifecycle.
+ *
+ * Call it inside `create()` / `update()` (after the plugin has been installed).
+ *
+ * @typeParam T - The theme config type. Pass your `ThemeType` to get
+ *   type-narrowed access to your custom tokens (through `hudini.pw`).
+ * @param scene - The Phaser scene instance.
+ * @returns The Hudini plugin instance bound to the given theme type.
+ *
+ * @example
+ * ```ts
+ * import { withHudini } from 'hudini';
+ * import type { ThemeType } from './theme';
+ *
+ * class MyScene extends Phaser.Scene {
+ *   create() {
+ *     const hudini = withHudini<ThemeType>(this);
+ *     const pw = hudini.pw;
+ *     this.cameras.main.setBackgroundColor(pw.color.rgb('background'));
+ *   }
+ * }
+ * ```
+ */
+export const withHudini = <T extends BaseThemeConfig = BaseThemeConfig>(
+  scene: Scene
+): HudiniPlugin<T> =>
+  scene.plugins.get(HUDINI_KEY) as unknown as HudiniPlugin<T>;

--- a/packages/phaser-wind/README.md
+++ b/packages/phaser-wind/README.md
@@ -283,82 +283,79 @@ new Phaser.Game({
 });
 ```
 
-### 3) How to get strong types in your scene
+### 3) Access the plugin from your scene with `withPhaserWind`
 
-#### 3.1 Lazy way. Define a module and all scenes should be have the "pw" instance
+Use the `withPhaserWind(scene)` accessor to get a fully typed handle to the plugin. It composes with any base scene, doesn't rely on global module augmentation, and infers your theme's tokens at the call site.
 
 ```ts
-// src/my-theme.ts
-import 'phaser';
-import type { PhaserWindPlugin } from 'phaser-wind';
-import type { ThemeType } from './theme';
+import Phaser from 'phaser';
+import { withPhaserWind } from 'phaser-wind';
+import type { ThemeType } from './theme'; // your createTheme() result
 
-const theme = const theme = createTheme({
-  colors: {
-    brand: 'purple-600',
-    danger: 'red-500',
-  }
-});
-export type ThemeType = typeof theme;
+class MyScene extends Phaser.Scene {
+  create(): void {
+    const pw = withPhaserWind<ThemeType>(this);
+    const { color, fontSize, spacing, radius, font, shadow } = pw;
 
-declare module 'phaser' {
-  interface Scene {
-    pw: PhaserWindPlugin<ThemeType>;
+    this.cameras.main.setBackgroundColor(color.rgb('background'));
+
+    this.add
+      .text(300, 100, 'Primary color', {
+        fontSize: fontSize.css('2xl'),
+        color: color.rgb('primary'), // ✅ Type-narrowed to your theme
+      })
+      .setOrigin(0.5);
+
+    // ✅ Type-narrowed to your theme
+    spacing.px('gutter');
+    radius.css('card');
+    font.family('display');
+    shadow.get('glow');
+
+    // ❌ Compile-time errors
+    // color.rgb('blue-501');
+    // spacing.px('unknown');
   }
 }
-
-// In your scene
-
-class MyCustomScene extends Phaser.Scene {
-    create(): void {
-      this.pw // <-- Valid instance in your ts file
 ```
 
-#### 3.1 - Cast way
+Call `withPhaserWind(this)` inside `create()` / `update()` (after the plugin has mounted). Don't call it in the constructor or `init()` — the plugin isn't attached yet.
 
-The original `Phaser.Scene` does not know the `pw` from Phaser-wind. You can make a simple cast to solve this problem
+### 4) Recommended: wrap it in a project-local helper
+
+Passing `<ThemeType>` on every call gets old. Define a one-line helper once in your project so scenes stay short and the theme type stays in one place:
+
+```ts
+// src/theme.ts (in your project)
+import type { Scene } from 'phaser';
+import { createTheme, withPhaserWind, type CreateTheme } from 'phaser-wind';
+
+export const theme = createTheme({
+  colors: { primary: 'blue-600', danger: 'red-500' },
+  // ...
+} satisfies CreateTheme<any>);
+
+export type ThemeType = typeof theme;
+
+/** Project-local accessor — no need to pass the theme type. */
+export const withPw = (scene: Scene) => withPhaserWind<ThemeType>(scene);
+```
+
+Now every scene is a one-liner:
 
 ```ts
 import Phaser from 'phaser';
-import { type ThemeType } from 'src/theme.ts' // In your project
+import { withPw } from './theme';
 
-class MyCustomScene extends Phaser.Scene {
-    create(): void {
-        const { pw } = (this as unknown as SceneWithPhaserWind<Theme>); // cast to get the pw property
-        this.cameras.main.setBackgroundColor(pw.color.slate(900));
-
-        this.add
-            .text(300, 100, 'Primary color', {
-                fontSize: pw.fontSize.css('2xl'), // use the pw property to get the font size
-                color: pw.color.rgb('primary'), // use the pw property to get the color with type safety
-            })
-            .setOrigin(0.5);
+class MyScene extends Phaser.Scene {
+  create(): void {
+    const pw = withPw(this); // fully typed against your theme
+    this.cameras.main.setBackgroundColor(pw.color.rgb('background'));
+  }
+}
 ```
 
-#### 3.2 - Inheritance way
-
-Phaser-wind export an abstract class to type the `Phaser.Scene` and add the attribute `pw`.
-
-```ts
-import Phaser from 'phaser';
-import { type ThemeType } from 'src/theme.ts' // In your project
-
-class PreviewScene extends SceneWithPhaserWind<ThemeType> { // Inherit from SceneWithPhaserWind to get the pw property
-    create(): void {
-      const { color, fontSize, spacing, radius, font, shadow } = this.pw; // Don't need to cast because we're using the generic type
-
-      // ✅ Type-narrowed to your theme
-      color.rgb('primary');
-      fontSize.css('lg');
-      spacing.px('gutter');
-      radius.css('card');
-      font.family('display');
-      shadow.get('glow');
-
-      // ❌ Compile-time errors
-      // color.rgb('blue-501');
-      // spacing.px('unknown');
-```
+You can name the helper whatever fits your style — `withPw`, `usePw`, `getPw`, `pw`. The lib intentionally doesn't ship an alias, so you own the naming in your codebase.
 
 ### 🎮 **Real Game Example**
 

--- a/packages/phaser-wind/src/core/index.ts
+++ b/packages/phaser-wind/src/core/index.ts
@@ -1,6 +1,7 @@
 export * from './color';
 export * from './font';
 export * from './font-size';
+export * from './opacity';
 export * from './palette';
 export * from './radius';
 export * from './shadow';

--- a/packages/phaser-wind/src/core/opacity.spec.ts
+++ b/packages/phaser-wind/src/core/opacity.spec.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { describe, expect, it } from 'vitest';
+
+import { createOpacity, Opacity } from './opacity';
+
+describe('Opacity', () => {
+  describe('value', () => {
+    it('should return alpha values in 0..1 range', () => {
+      const opacity = createOpacity();
+      expect(opacity.value('0')).toBe(0);
+      expect(opacity.value('50')).toBe(0.5);
+      expect(opacity.value('100')).toBe(1);
+    });
+
+    it('should handle every tailwind step', () => {
+      const opacity = createOpacity();
+      expect(opacity.value('5')).toBe(0.05);
+      expect(opacity.value('25')).toBe(0.25);
+      expect(opacity.value('75')).toBe(0.75);
+      expect(opacity.value('95')).toBe(0.95);
+    });
+  });
+
+  describe('percent', () => {
+    it('should return values as percentages (0..100)', () => {
+      const opacity = createOpacity();
+      expect(opacity.percent('0')).toBe(0);
+      expect(opacity.percent('50')).toBe(50);
+      expect(opacity.percent('100')).toBe(100);
+    });
+  });
+
+  describe('css', () => {
+    it('should return CSS opacity strings', () => {
+      const opacity = createOpacity();
+      expect(opacity.css('0')).toBe('0%');
+      expect(opacity.css('50')).toBe('50%');
+      expect(opacity.css('100')).toBe('100%');
+    });
+
+    it('should work with default Opacity constant', () => {
+      expect(Opacity.value('50')).toBe(0.5);
+      expect(Opacity.percent('75')).toBe(75);
+      expect(Opacity.css('25')).toBe('25%');
+    });
+  });
+
+  describe('theme override', () => {
+    it('should resolve custom theme opacity keys', () => {
+      const opacity = createOpacity({ faded: 0.35, ghost: 0.08 });
+      expect(opacity.value('faded')).toBe(0.35);
+      expect(opacity.value('ghost')).toBe(0.08);
+    });
+
+    it('should keep default tokens available alongside theme keys', () => {
+      const opacity = createOpacity({ faded: 0.35 });
+      expect(opacity.value('50')).toBe(0.5);
+      expect(opacity.value('faded')).toBe(0.35);
+    });
+
+    it('should let theme keys override default keys with the same name', () => {
+      const opacity = createOpacity({ '50': 0.42 });
+      expect(opacity.value('50')).toBe(0.42);
+    });
+  });
+});

--- a/packages/phaser-wind/src/core/opacity.ts
+++ b/packages/phaser-wind/src/core/opacity.ts
@@ -1,0 +1,120 @@
+import type { BaseThemeConfig } from '../theme';
+
+/**
+ * Valid opacity scale keys following Tailwind's opacity scale.
+ * Values map to alpha in the 0..1 range (Phaser's `setAlpha` range).
+ */
+export type OpacityKey =
+  | '0'
+  | '5'
+  | '10'
+  | '15'
+  | '20'
+  | '25'
+  | '30'
+  | '35'
+  | '40'
+  | '45'
+  | '50'
+  | '55'
+  | '60'
+  | '65'
+  | '70'
+  | '75'
+  | '80'
+  | '85'
+  | '90'
+  | '95'
+  | '100';
+
+/** Maps opacity scale keys to their 0..1 alpha values. */
+export type OpacityMap = Record<OpacityKey | string, number>;
+
+/**
+ * Opacity scale mapping following Tailwind's opacity scale.
+ * Values are in the 0..1 range, ready for Phaser's `setAlpha()`.
+ */
+export const opacityMap: OpacityMap = {
+  '0': 0,
+  '5': 0.05,
+  '10': 0.1,
+  '15': 0.15,
+  '20': 0.2,
+  '25': 0.25,
+  '30': 0.3,
+  '35': 0.35,
+  '40': 0.4,
+  '45': 0.45,
+  '50': 0.5,
+  '55': 0.55,
+  '60': 0.6,
+  '65': 0.65,
+  '70': 0.7,
+  '75': 0.75,
+  '80': 0.8,
+  '85': 0.85,
+  '90': 0.9,
+  '95': 0.95,
+  '100': 1,
+};
+
+/**
+ * API for resolving opacity tokens.
+ * Accepted keys are narrowed to default tokens plus theme keys.
+ */
+export type OpacityApi<T extends OpacityMap | undefined> = {
+  /** Alpha value in 0..1 range, ready for Phaser's `setAlpha()`. */
+  value: (key: OpacityKey | (T extends OpacityMap ? keyof T : never)) => number;
+  /** Percentage as a number (0..100). */
+  percent: (
+    key: OpacityKey | (T extends OpacityMap ? keyof T : never)
+  ) => number;
+  /** CSS opacity string like `'50%'`. */
+  css: (key: OpacityKey | (T extends OpacityMap ? keyof T : never)) => string;
+};
+
+/**
+ * Create an opacity API bound to an optional theme opacity map.
+ * @example
+ * const o = createOpacity({ faded: 0.35 });
+ * o.value('faded'); // 0.35
+ * o.value('50');    // 0.5
+ */
+export const createOpacity = <
+  T extends OpacityMap | undefined = BaseThemeConfig['opacity'],
+>(
+  themeOpacity?: T
+): OpacityApi<T> => {
+  const map: OpacityMap = {
+    ...opacityMap,
+    ...(themeOpacity as OpacityMap | undefined),
+  } as OpacityMap;
+
+  const get = (key: string): number => {
+    return typeof map[key] === 'number' ? (map[key] as number) : 0;
+  };
+
+  return {
+    value: (
+      key: OpacityKey | (T extends OpacityMap ? keyof T : never)
+    ): number => {
+      return get(key as string);
+    },
+    percent: (
+      key: OpacityKey | (T extends OpacityMap ? keyof T : never)
+    ): number => {
+      const ONE_HUNDRED = 100;
+      return get(key as string) * ONE_HUNDRED;
+    },
+    css: (
+      key: OpacityKey | (T extends OpacityMap ? keyof T : never)
+    ): string => {
+      const ONE_HUNDRED = 100;
+      return `${get(key as string) * ONE_HUNDRED}%`;
+    },
+  };
+};
+
+/** Convenience instance using default opacity map (no theme). */
+export const Opacity: OpacityApi<undefined> =
+  createOpacity<undefined>(undefined);

--- a/packages/phaser-wind/src/plugin/plugin.ts
+++ b/packages/phaser-wind/src/plugin/plugin.ts
@@ -11,6 +11,7 @@ import {
   type ShadowApi,
 } from '../core';
 import { createColor, type Color } from '../core/color';
+import { createOpacity, type OpacityApi } from '../core/opacity';
 import { createRadius, type RadiusApi } from '../core/radius';
 import {
   BaseThemeConfig,
@@ -45,6 +46,7 @@ export class PhaserWindPlugin<
   private fontSizeInstance: FontSizeApi<T['fontSizes']> | null = null;
   private spacingInstance: SpacingApi<T['spacing']> | null = null;
   private radiusInstance: RadiusApi<T['radius']> | null = null;
+  private opacityInstance: OpacityApi<T['opacity']> | null = null;
   private fontInstance: FontApi<T['fonts'], T['fontSizes']> | null = null;
   private shadowInstance: ShadowApi<T['effects']> | null = null;
 
@@ -103,6 +105,9 @@ export class PhaserWindPlugin<
     this.radiusInstance = createRadius<T['radius']>(
       this.theme.radius as T['radius']
     );
+    this.opacityInstance = createOpacity<T['opacity']>(
+      this.theme.opacity as T['opacity']
+    );
     this.fontInstance = createFont(
       this.theme.fonts as T['fonts'],
       this.theme.fontSizes as T['fontSizes']
@@ -132,6 +137,10 @@ export class PhaserWindPlugin<
 
   public get radius(): RadiusApi<T['radius']> {
     return this.radiusInstance as RadiusApi<T['radius']>;
+  }
+
+  public get opacity(): OpacityApi<T['opacity']> {
+    return this.opacityInstance as OpacityApi<T['opacity']>;
   }
 
   public get font(): FontApi<T['fonts'], T['fontSizes']> {

--- a/packages/phaser-wind/src/scene/index.ts
+++ b/packages/phaser-wind/src/scene/index.ts
@@ -1,1 +1,2 @@
 export * from './scene-with-phaser-wind';
+export * from './with-phaser-wind';

--- a/packages/phaser-wind/src/scene/scene-with-phaser-wind.ts
+++ b/packages/phaser-wind/src/scene/scene-with-phaser-wind.ts
@@ -1,11 +1,33 @@
 import { PhaserWindPlugin } from '../plugin/plugin';
 import { BaseThemeConfig } from '../theme';
 
+/**
+ * @deprecated Use {@link withPhaserWind} instead.
+ *
+ * Forces single inheritance, which conflicts with any user-defined `BaseScene`
+ * or other libraries that ship their own scene base class. It also relies on a
+ * non-null assertion (`pw!`) that lies to TypeScript about when the plugin is
+ * available — touching `this.pw` before the plugin mounts throws at runtime.
+ *
+ * Prefer the `withPhaserWind(scene)` accessor:
+ *
+ * ```ts
+ * import { withPhaserWind } from 'phaser-wind';
+ * import type { ThemeType } from './theme';
+ *
+ * class MyScene extends Phaser.Scene {
+ *   create() {
+ *     const pw = withPhaserWind<ThemeType>(this);
+ *   }
+ * }
+ * ```
+ *
+ * Kept exported to avoid breaking existing consumers.
+ */
 export abstract class SceneWithPhaserWind<
   T extends BaseThemeConfig = BaseThemeConfig,
 > extends Phaser.Scene {
   /**
-   *
    * @param config The scene key or scene specific configuration settings.
    */
   constructor(config?: string | Phaser.Types.Scenes.SettingsConfig) {

--- a/packages/phaser-wind/src/scene/with-phaser-wind.ts
+++ b/packages/phaser-wind/src/scene/with-phaser-wind.ts
@@ -1,0 +1,38 @@
+import type { Scene } from 'phaser';
+
+import { PHASER_WIND_KEY, PhaserWindPlugin } from '../plugin/plugin';
+import { BaseThemeConfig } from '../theme';
+
+/**
+ * Accessor for the Phaser Wind plugin from within a Phaser scene.
+ *
+ * Preferred over {@link SceneWithPhaserWind} (inheritance) and over module
+ * augmentation of `Phaser.Scene`, because it:
+ * - Composes with any existing base scene (no forced inheritance).
+ * - Keeps the theme type explicit at the call site (no silent `any`).
+ * - Doesn't rely on non-null assertions that lie about lifecycle.
+ *
+ * Call it inside `create()` / `update()` (after the plugin has been installed).
+ *
+ * @typeParam T - The theme config type. Pass your `ThemeType` to get
+ *   type-narrowed access to your custom tokens.
+ * @param scene - The Phaser scene instance.
+ * @returns The Phaser Wind plugin instance bound to the given theme type.
+ *
+ * @example
+ * ```ts
+ * import { withPhaserWind } from 'phaser-wind';
+ * import type { ThemeType } from './theme';
+ *
+ * class MyScene extends Phaser.Scene {
+ *   create() {
+ *     const pw = withPhaserWind<ThemeType>(this);
+ *     this.cameras.main.setBackgroundColor(pw.color.rgb('background'));
+ *   }
+ * }
+ * ```
+ */
+export const withPhaserWind = <T extends BaseThemeConfig = BaseThemeConfig>(
+  scene: Scene
+): PhaserWindPlugin<T> =>
+  scene.plugins.get(PHASER_WIND_KEY) as unknown as PhaserWindPlugin<T>;

--- a/packages/phaser-wind/src/theme/theme-config.ts
+++ b/packages/phaser-wind/src/theme/theme-config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable sonarjs/no-duplicate-string */
 import { fontSizeMap, type FontSizeMap } from '../core/font-size';
+import { opacityMap, type OpacityMap } from '../core/opacity';
 import { radiusMap, type RadiusMap } from '../core/radius';
 import { spacingMap } from '../core/spacing';
 
@@ -43,6 +44,7 @@ export type ThemeOverride = {
   typography?: Partial<TypographyConfig>;
   effects?: Partial<EffectConfig>;
   radius?: Partial<RadiusMap> & { [key: string]: number };
+  opacity?: Partial<OpacityMap> & { [key: string]: number };
   custom?: { [key: string]: unknown };
 };
 
@@ -58,6 +60,9 @@ export type BaseThemeConfig = {
   typography?: TypographyConfig;
   effects?: EffectConfig;
   radius?: RadiusMap & {
+    [key: string]: number;
+  };
+  opacity?: OpacityMap & {
     [key: string]: number;
   };
   custom?: {
@@ -98,6 +103,7 @@ export const defaultLightTheme: BaseThemeConfig = {
     overlay: 'black',
   },
   spacing: { ...spacingMap },
+  opacity: { ...opacityMap },
   typography: {
     heading: {
       fontSize: '2xl',
@@ -179,6 +185,7 @@ export const defaultDarkTheme: BaseThemeConfig = {
     overlay: 'black',
   },
   spacing: { ...spacingMap },
+  opacity: { ...opacityMap },
   typography: {
     heading: {
       fontSize: '2xl',

--- a/packages/showcase/.astro/settings.json
+++ b/packages/showcase/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1762789081938
+		"lastUpdateCheck": 1783119824476
 	}
 }

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -24,6 +24,26 @@ const getUrl = (path: string) => {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href={getUrl('/favicon.svg')} />
     <title>{title}</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/atom-one-dark.min.css"
+    />
+    <script
+      is:inline
+      src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"
+    ></script>
+    <script is:inline>
+      document.addEventListener('DOMContentLoaded', function () {
+        if (window.hljs) {
+          document.querySelectorAll('pre code').forEach(function (block) {
+            if (!block.className.match(/\blanguage-/)) {
+              block.classList.add('language-typescript');
+            }
+            window.hljs.highlightElement(block);
+          });
+        }
+      });
+    </script>
     <style>
       .sidebar-collapsed {
         width: 4rem !important;

--- a/packages/showcase/src/pages/hudini/advanced-card-usage-column.astro
+++ b/packages/showcase/src/pages/hudini/advanced-card-usage-column.astro
@@ -108,10 +108,10 @@ class AdvancedCardColumnScene extends Phaser.Scene {
 </Layout>
 
 <script>
-  import { loadFonts, Card, Column, IconButton, Color, createTheme, HUDINI_KEY, HudiniPlugin, SceneWithHudini } from 'hudini';
+  import { loadFonts, Card, Column, IconButton, Color, createTheme, HUDINI_KEY, HudiniPlugin } from 'hudini';
   import { loadFont } from 'font-awesome-for-phaser';
 
-  class AdvancedCardColumnScene extends SceneWithHudini {
+  class AdvancedCardColumnScene extends Phaser.Scene {
     constructor() {
       super('advanced-card-column');
     }

--- a/packages/showcase/src/pages/hudini/advanced-card-usage-modal.astro
+++ b/packages/showcase/src/pages/hudini/advanced-card-usage-modal.astro
@@ -98,15 +98,16 @@ const closeButton = new FlatIconButton({
 </Layout>
 
 <script>
-  import { loadFonts, Card, Column, Row, TextButton, FlatIconButton, SizedBox, defaultLightTheme, HUDINI_KEY, HudiniPlugin, HudiniPluginData, SceneWithHudini } from 'hudini';
+  import { loadFonts, Card, Column, Row, TextButton, FlatIconButton, SizedBox, defaultLightTheme, HUDINI_KEY, HudiniPlugin, HudiniPluginData, withHudini } from 'hudini';
 
-  class AdvancedCardModalScene extends SceneWithHudini {
+  class AdvancedCardModalScene extends Phaser.Scene {
     constructor() {
       super('advanced-card-modal');
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini(this);
+      const { pw } = hudini;
       const { width, centerY, centerX } = this.cameras.main;
       
       this.cameras.main.setBackgroundColor(pw.color.slate(900));

--- a/packages/showcase/src/pages/hudini/advanced-card-usage.astro
+++ b/packages/showcase/src/pages/hudini/advanced-card-usage.astro
@@ -107,10 +107,10 @@ class AdvancedCardScene extends Phaser.Scene {
 </Layout>
 
 <script>
-  import { loadFonts, Card, Row, IconButton, Color, createTheme, HUDINI_KEY, HudiniPlugin, SceneWithHudini } from 'hudini';
+  import { loadFonts, Card, Row, IconButton, Color, createTheme, HUDINI_KEY, HudiniPlugin } from 'hudini';
   import { loadFont } from 'font-awesome-for-phaser';
 
-  class AdvancedCardUsageScene extends SceneWithHudini {
+  class AdvancedCardUsageScene extends Phaser.Scene {
     constructor() {
       super('advanced-card-usage');
     }

--- a/packages/showcase/src/pages/hudini/card.astro
+++ b/packages/showcase/src/pages/hudini/card.astro
@@ -54,7 +54,7 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Card,
     TextButton
 } from 'hudini';
@@ -64,13 +64,14 @@ const theme = createTheme({
 });
 type Theme = typeof theme;
 
-class PreviewScene extends SceneWithHudini<Theme> {
+class PreviewScene extends Phaser.Scene {
     constructor() {
         super('preview');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a button to put inside the card
@@ -110,7 +111,7 @@ class PreviewScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Card,
     TextButton,
     Row
@@ -120,7 +121,7 @@ class PreviewScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class CardDemoScene extends SceneWithHudini<Theme> {
+  class CardDemoScene extends Phaser.Scene {
     private cards: Card[] = [];
 
     constructor() {
@@ -128,7 +129,8 @@ class PreviewScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/circular-progress.astro
+++ b/packages/showcase/src/pages/hudini/circular-progress.astro
@@ -65,20 +65,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     CircularProgress
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ProgressDemoScene extends SceneWithHudini<Theme> {
+class ProgressDemoScene extends Phaser.Scene {
     constructor() {
         super('progress-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Default circular progress
@@ -123,7 +124,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     CircularProgress
   } from 'hudini';
   import { loadFont } from 'font-awesome-for-phaser';
@@ -132,7 +133,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class CircularProgressDemoScene extends SceneWithHudini<Theme> {
+  class CircularProgressDemoScene extends Phaser.Scene {
     private progresses: CircularProgress[] = [];
     private controls: Phaser.GameObjects.Text[] = [];
 
@@ -141,7 +142,8 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/column.astro
+++ b/packages/showcase/src/pages/hudini/column.astro
@@ -53,20 +53,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Column
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ColumnDemoScene extends SceneWithHudini<Theme> {
+class ColumnDemoScene extends Phaser.Scene {
     constructor() {
         super('column-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create sprites
@@ -102,7 +103,7 @@ class ColumnDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Column,
     Card
   } from 'hudini';
@@ -111,7 +112,7 @@ class ColumnDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class ColumnDemoScene extends SceneWithHudini<Theme> {
+  class ColumnDemoScene extends Phaser.Scene {
     private columns: Column[] = [];
 
     constructor() {
@@ -119,7 +120,8 @@ class ColumnDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/flat-icon-button.astro
+++ b/packages/showcase/src/pages/hudini/flat-icon-button.astro
@@ -75,7 +75,7 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatIconButton
 } from 'hudini';
 import { loadFont } from 'font-awesome-for-phaser';
@@ -83,13 +83,14 @@ import { loadFont } from 'font-awesome-for-phaser';
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ButtonDemoScene extends SceneWithHudini<Theme> {
+class ButtonDemoScene extends Phaser.Scene {
     constructor() {
         super('button-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a flat icon button
@@ -243,7 +244,7 @@ button.setBorderRadius('full');`}</code></pre>
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatIconButton,
   } from 'hudini';
 import { type IconKey, loadFont } from 'font-awesome-for-phaser';
@@ -253,7 +254,7 @@ import { type ColorKey, type FontSizeKey } from 'phaser-wind';
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class FlatIconButtonDemoScene extends SceneWithHudini<Theme> {
+  class FlatIconButtonDemoScene extends Phaser.Scene {
     private buttons: FlatIconButton[] = [];
     private clickCount = 0;
     private clickText?: Phaser.GameObjects.Text;
@@ -263,7 +264,8 @@ import { type ColorKey, type FontSizeKey } from 'phaser-wind';
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/flat-section-header.astro
+++ b/packages/showcase/src/pages/hudini/flat-section-header.astro
@@ -55,20 +55,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatSectionHeader
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class PreviewScene extends SceneWithHudini<Theme> {
+class PreviewScene extends Phaser.Scene {
     constructor() {
         super('preview');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a simple flat section header
@@ -170,7 +171,7 @@ dynamicHeader
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatSectionHeader
   } from 'hudini';
 
@@ -178,7 +179,7 @@ dynamicHeader
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class FlatSectionHeaderDemoScene extends SceneWithHudini<Theme> {
+  class FlatSectionHeaderDemoScene extends Phaser.Scene {
     private headers: FlatSectionHeader[] = [];
 
     constructor() {
@@ -186,7 +187,8 @@ dynamicHeader
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/flat-text-button.astro
+++ b/packages/showcase/src/pages/hudini/flat-text-button.astro
@@ -52,20 +52,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatTextButton
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ButtonDemoScene extends SceneWithHudini<Theme> {
+class ButtonDemoScene extends Phaser.Scene {
     constructor() {
         super('button-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a primary button
@@ -107,7 +108,7 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     FlatTextButton
   } from 'hudini';
 
@@ -115,7 +116,7 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class FlatTextButtonDemoScene extends SceneWithHudini<Theme> {
+  class FlatTextButtonDemoScene extends Phaser.Scene {
     private buttons: FlatTextButton[] = [];
 
     constructor() {
@@ -123,7 +124,8 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/icon-button.astro
+++ b/packages/showcase/src/pages/hudini/icon-button.astro
@@ -66,20 +66,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     IconButton
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ButtonDemoScene extends SceneWithHudini<Theme> {
+class ButtonDemoScene extends Phaser.Scene {
     constructor() {
         super('button-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a heart icon button
@@ -190,7 +191,7 @@ button.setBorderRadius('lg');`}</code></pre>
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     IconButton,
   } from 'hudini';
 import { type IconKey, loadFont } from 'font-awesome-for-phaser';
@@ -200,7 +201,7 @@ import { type ColorKey, type ColorToken, type FontSizeKey } from 'phaser-wind';
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class IconButtonDemoScene extends SceneWithHudini<Theme> {
+  class IconButtonDemoScene extends Phaser.Scene {
     private buttons: IconButton[] = [];
     private clickCount = 0;
     private clickText?: Phaser.GameObjects.Text;
@@ -210,7 +211,8 @@ import { type ColorKey, type ColorToken, type FontSizeKey } from 'phaser-wind';
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -122,7 +122,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Styled header component for organizing content sections</p>
         </a>
 
-        <a href="/hudini/circular-progress" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/circular-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">⭕</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Circular Progress</h4>

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -16,14 +16,14 @@ const getUrl = (path: string) => {
     <div class="bg-gradient-to-r from-blue-600 to-blue-800 rounded-lg p-8 text-white">
       <h2 class="text-3xl font-bold mb-4">Hudini</h2>
       <p class="text-lg mb-6">
-        A powerful utility library with UI components and tools built on top of PhaserWind. 
+        A powerful utility library with UI components and tools built on top of PhaserWind.
         Create beautiful, responsive game interfaces with ease.
       </p>
       <div class="flex space-x-4">
-        <a href="/hudini/card" class="bg-white text-blue-600 px-6 py-3 rounded-lg font-medium hover:bg-gray-100 transition-colors">
+          <a href={getUrl('/hudini/card')} class="bg-white text-blue-600 px-6 py-3 rounded-lg font-medium hover:bg-gray-100 transition-colors">
           Explore Components
         </a>
-        <a href="https://github.com/your-org/hudini" class="border border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-blue-600 transition-colors">
+        <a href="https://github.com/renatocassino/phaser-toolkit/tree/main/packages/hudini" class="border border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-blue-600 transition-colors">
           View on GitHub
         </a>
       </div>
@@ -90,7 +90,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Flexible container component that adapts to its content</p>
         </a>
 
-        <a href="/hudini/text-button" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/text-button')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">🔘</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Text Button</h4>
@@ -98,7 +98,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Interactive button with text content and hover effects</p>
         </a>
 
-        <a href="/hudini/icon-button" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/icon-button')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">🎯</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Icon Button</h4>
@@ -114,7 +114,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Minimalist icon button with flat design</p>
         </a>
 
-        <a href="/hudini/section-header" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/section-header')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">📑</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Section Header</h4>
@@ -130,7 +130,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Circular progress indicator with smooth animations</p>
         </a>
 
-        <a href="/hudini/linear-progress" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/linear-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">📊</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Linear Progress</h4>
@@ -138,7 +138,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Horizontal progress bar with customizable styling</p>
         </a>
 
-        <a href="/hudini/radial-progress" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/radial-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">🎯</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Radial Progress</h4>
@@ -146,7 +146,7 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Radial progress indicator with customizable arc</p>
         </a>
 
-        <a href="/hudini/column" class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+        <a href={getUrl('/hudini/column')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">📦</span>
             <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Column</h4>

--- a/packages/showcase/src/pages/hudini/install-base-scene.astro
+++ b/packages/showcase/src/pages/hudini/install-base-scene.astro
@@ -3,21 +3,21 @@ import Layout from '../../layouts/Layout.astro';
 import PhaserGame from '../../components/PhaserGame.astro';
 ---
 
-<Layout title="Hudini Install - Base Scene" description="Examples of how to install and use Hudini with SceneWithHudini base class.">
+<Layout title="Hudini Install - withHudini Hook" description="Examples of how to install and use Hudini with the withHudini accessor.">
   <div class="space-y-8">
     <!-- Description -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-      <h2 class="text-xl font-semibold text-gray-900 mb-4">Install - Base Scene</h2>
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Install - withHudini Hook</h2>
       <p class="text-gray-600 mb-4">
-        Examples of how to install and use Hudini with SceneWithHudini base class for type-safe theming and utilities.
+        Examples of how to install and use Hudini with the withHudini accessor for type-safe theming and utilities.
       </p>
-      
+
       <!-- Features -->
       <div class="mb-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
         <ul class="list-disc list-inside space-y-1 text-gray-600">
           <li>🎨 <strong>Type-Safe Theming</strong>: Full TypeScript support for custom themes</li>
-          <li>🔧 <strong>Base Scene Class</strong>: SceneWithHudini provides easy access to utilities</li>
+          <li>🔧 <strong>Accessor Hook</strong>: withHudini(scene) provides easy access to utilities</li>
           <li>🎯 <strong>Color Management</strong>: Type-safe color access with custom theme colors</li>
           <li>📏 <strong>Font Sizing</strong>: Consistent font sizing with theme integration</li>
           <li>⚡ <strong>Performance</strong>: Optimized for 60fps gameplay</li>
@@ -38,7 +38,7 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini
+    withHudini
 } from 'hudini';
 
 const theme = createTheme({
@@ -50,13 +50,14 @@ const theme = createTheme({
 });
 type Theme = typeof theme;
 
-class PreviewScene extends SceneWithHudini<Theme> {
+class PreviewScene extends Phaser.Scene {
     constructor() {
         super('preview');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         let y = 90;
@@ -117,8 +118,8 @@ class PreviewScene extends SceneWithHudini<Theme> {
             <span class="text-sm font-semibold text-blue-600">3</span>
           </div>
           <div>
-            <h4 class="font-medium text-gray-900">Extend SceneWithHudini</h4>
-            <p class="text-sm text-gray-600">Use SceneWithHudini as your base scene class for type safety</p>
+            <h4 class="font-medium text-gray-900">Access with withHudini</h4>
+            <p class="text-sm text-gray-600">Call withHudini(this) inside create() to get a type-safe handle to the plugin</p>
           </div>
         </div>
         
@@ -137,7 +138,7 @@ class PreviewScene extends SceneWithHudini<Theme> {
 </Layout>
 
 <script>
-  import { loadFonts, Color, createTheme, HUDINI_KEY, HudiniPlugin, SceneWithHudini } from 'hudini';
+  import { loadFonts, Color, createTheme, HUDINI_KEY, HudiniPlugin, withHudini } from 'hudini';
 
   const theme = createTheme({
     colors: {
@@ -148,13 +149,14 @@ class PreviewScene extends SceneWithHudini<Theme> {
   });
   type Theme = typeof theme;
 
-  class InstallBaseSceneDemo extends SceneWithHudini<Theme> {
+  class InstallBaseSceneDemo extends Phaser.Scene {
     constructor() {
       super('install-base-scene');
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       let y = 90;

--- a/packages/showcase/src/pages/hudini/linear-progress.astro
+++ b/packages/showcase/src/pages/hudini/linear-progress.astro
@@ -69,14 +69,14 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     LinearProgress
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ProgressDemoScene extends SceneWithHudini<Theme> {
+class ProgressDemoScene extends Phaser.Scene {
     private progressBar?: LinearProgress;
 
     constructor() {
@@ -84,7 +84,8 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a progress bar
@@ -127,7 +128,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     LinearProgress
   } from 'hudini';
 
@@ -135,7 +136,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class LinearProgressDemoScene extends SceneWithHudini<Theme> {
+  class LinearProgressDemoScene extends Phaser.Scene {
     private progressBars: LinearProgress[] = [];
     private indeterminateBar?: LinearProgress;
     private controllableBar?: LinearProgress;
@@ -148,7 +149,8 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/panel.astro
+++ b/packages/showcase/src/pages/hudini/panel.astro
@@ -79,7 +79,7 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Panel,
     Column,
     TextButton
@@ -88,13 +88,14 @@ import {
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class PanelDemoScene extends SceneWithHudini<Theme> {
+class PanelDemoScene extends Phaser.Scene {
     constructor() {
         super('panel-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create content for the panel
@@ -224,7 +225,7 @@ panel.setMargin(24);`}</code></pre>
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Panel,
     Column,
     Row,
@@ -238,7 +239,7 @@ import { loadFont } from 'font-awesome-for-phaser';
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class PanelDemoScene extends SceneWithHudini<Theme> {
+  class PanelDemoScene extends Phaser.Scene {
     private panels: Panel[] = [];
 
     constructor() {
@@ -246,7 +247,8 @@ import { loadFont } from 'font-awesome-for-phaser';
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/radial-progress.astro
+++ b/packages/showcase/src/pages/hudini/radial-progress.astro
@@ -77,14 +77,14 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     RadialProgress
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ProgressDemoScene extends SceneWithHudini<Theme> {
+class ProgressDemoScene extends Phaser.Scene {
     private progressBar?: RadialProgress;
 
     constructor() {
@@ -92,7 +92,8 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a radial progress bar with text
@@ -138,7 +139,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     RadialProgress
   } from 'hudini';
 
@@ -146,7 +147,7 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class RadialProgressDemoScene extends SceneWithHudini<Theme> {
+  class RadialProgressDemoScene extends Phaser.Scene {
     private progressBars: RadialProgress[] = [];
     private controllableBar?: RadialProgress;
     private progressValue: number = 0;
@@ -156,7 +157,8 @@ class ProgressDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/row.astro
+++ b/packages/showcase/src/pages/hudini/row.astro
@@ -53,20 +53,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Row
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class RowDemoScene extends SceneWithHudini<Theme> {
+class RowDemoScene extends Phaser.Scene {
     constructor() {
         super('row-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create sprites
@@ -102,7 +103,7 @@ class RowDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     Row,
     Card
   } from 'hudini';
@@ -111,7 +112,7 @@ class RowDemoScene extends SceneWithHudini<Theme> {
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class RowDemoScene extends SceneWithHudini<Theme> {
+  class RowDemoScene extends Phaser.Scene {
     private rows: Row[] = [];
 
     constructor() {
@@ -119,7 +120,8 @@ class RowDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/section-header.astro
+++ b/packages/showcase/src/pages/hudini/section-header.astro
@@ -56,20 +56,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     SectionHeader
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class PreviewScene extends SceneWithHudini<Theme> {
+class PreviewScene extends Phaser.Scene {
     constructor() {
         super('preview');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a simple section header
@@ -174,7 +175,7 @@ dynamicHeader
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     SectionHeader
   } from 'hudini';
 
@@ -182,7 +183,7 @@ dynamicHeader
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class SectionHeaderDemoScene extends SceneWithHudini<Theme> {
+  class SectionHeaderDemoScene extends Phaser.Scene {
     private headers: SectionHeader[] = [];
 
     constructor() {
@@ -190,7 +191,8 @@ dynamicHeader
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/sized-box.astro
+++ b/packages/showcase/src/pages/hudini/sized-box.astro
@@ -67,7 +67,7 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     SizedBox,
     Column,
     Row,
@@ -77,13 +77,14 @@ import {
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class LayoutDemoScene extends SceneWithHudini<Theme> {
+class LayoutDemoScene extends Phaser.Scene {
     constructor() {
         super('layout-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create buttons
@@ -196,7 +197,7 @@ spacer.setSize(100, 50);`}</code></pre>
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     SizedBox,
     Column,
     Row,
@@ -209,13 +210,14 @@ import { loadFont } from 'font-awesome-for-phaser';
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class SizedBoxDemoScene extends SceneWithHudini<Theme> {
+  class SizedBoxDemoScene extends Phaser.Scene {
     constructor() {
       super('sized-box-demo');
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const hudini = withHudini<Theme>(this);
+      const { pw } = hudini;
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/text-button.astro
+++ b/packages/showcase/src/pages/hudini/text-button.astro
@@ -55,20 +55,21 @@ import {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     TextButton
 } from 'hudini';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ButtonDemoScene extends SceneWithHudini<Theme> {
+class ButtonDemoScene extends Phaser.Scene {
     constructor() {
         super('button-demo');
     }
 
     create(): void {
-        const { pw } = this.hudini;
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
         this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
         // Create a primary button
@@ -111,9 +112,8 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
     createTheme,
     HUDINI_KEY,
     HudiniPlugin,
-    SceneWithHudini,
+    withHudini,
     TextButton,
-withPhaserWind
   } from 'hudini';
 
   // Create theme
@@ -128,7 +128,7 @@ withPhaserWind
     }
 
     create(): void {
-      const pw = withPhaserWind(this);
+      const { pw } = withHudini(this);
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/hudini/text-button.astro
+++ b/packages/showcase/src/pages/hudini/text-button.astro
@@ -14,7 +14,7 @@ import PhaserGame from '../../components/PhaserGame.astro';
       <p class="text-gray-600 mb-4">
         Interactive button with text content and hover effects, built with PhaserWind theming system.
       </p>
-      
+
       <!-- Features -->
       <div class="mb-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
@@ -104,7 +104,7 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
 </Layout>
 
 <script>
-  import Phaser from 'phaser';
+  import Phaser, { Scene } from 'phaser';
   import {
     loadFonts,
     type RadiusKey,
@@ -112,14 +112,15 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
     HUDINI_KEY,
     HudiniPlugin,
     SceneWithHudini,
-    TextButton
+    TextButton,
+withPhaserWind
   } from 'hudini';
 
   // Create theme
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class TextButtonDemoScene extends SceneWithHudini<Theme> {
+  class TextButtonDemoScene extends Scene {
     private buttons: TextButton[] = [];
 
     constructor() {
@@ -127,7 +128,7 @@ class ButtonDemoScene extends SceneWithHudini<Theme> {
     }
 
     create(): void {
-      const { pw } = this.hudini;
+      const pw = withPhaserWind(this);
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
       // Title

--- a/packages/showcase/src/pages/index.astro
+++ b/packages/showcase/src/pages/index.astro
@@ -16,14 +16,14 @@ const getUrl = (path: string) => {
     <div class="bg-gradient-to-r from-primary-600 to-primary-800 rounded-lg p-8 text-white">
       <h2 class="text-3xl font-bold mb-4">Welcome to Phaser Toolkit</h2>
       <p class="text-lg mb-6">
-        A comprehensive collection of tools and components for building amazing Phaser 3 games. 
+        A comprehensive collection of tools and components for building amazing Phaser 3 games.
         Explore interactive examples, copy code snippets, and see everything in action.
       </p>
       <div class="flex space-x-4">
         <a href={getUrl('/hudini')} class="bg-white text-primary-600 px-6 py-3 rounded-lg font-medium hover:bg-gray-100 transition-colors">
           Explore Components
         </a>
-        <a href="https://github.com/your-org/phaser-toolkit" class="border border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-primary-600 transition-colors">
+        <a href="https://github.com/renatocassino/phaser-toolkit" class="border border-white text-white px-6 py-3 rounded-lg font-medium hover:bg-white hover:text-primary-600 transition-colors">
           View on GitHub
         </a>
       </div>
@@ -40,7 +40,7 @@ const getUrl = (path: string) => {
           <h3 class="text-lg font-semibold text-gray-900">Hudini</h3>
         </div>
         <p class="text-gray-600 mb-4">
-          A powerful utility library with UI components and tools built on top of PhaserWind. 
+          A powerful utility library with UI components and tools built on top of PhaserWind.
           Create beautiful, responsive game interfaces with ease.
         </p>
         <div class="flex flex-wrap gap-2 mb-4">
@@ -48,7 +48,7 @@ const getUrl = (path: string) => {
           <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">Theming</span>
           <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">Responsive</span>
         </div>
-        <a href="/hudini" class="text-primary-600 hover:text-primary-700 font-medium">
+        <a href={getUrl('/hudini')} class="text-primary-600 hover:text-primary-700 font-medium">
           Explore Components →
         </a>
       </div>
@@ -163,7 +163,7 @@ const getUrl = (path: string) => {
     <div class="bg-primary-50 rounded-lg p-6">
       <h2 class="text-xl font-semibold text-primary-900 mb-3">Getting Started</h2>
       <p class="text-primary-700 mb-4">
-        This showcase demonstrates all the components and features available in the Phaser Toolkit ecosystem. 
+        This showcase demonstrates all the components and features available in the Phaser Toolkit ecosystem.
         Use the sidebar to navigate between different components and see them in action.
       </p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/packages/showcase/src/pages/phaser-sound-studio/main.astro
+++ b/packages/showcase/src/pages/phaser-sound-studio/main.astro
@@ -108,7 +108,7 @@ class GameScene extends Phaser.Scene {
 
 <script>
   import { getSoundStudio, PHASER_SOUND_STUDIO_KEY, PhaserSoundStudioPlugin, PhaserSoundStudioPluginData, SoundListConfig } from 'phaser-sound-studio';
-  import { Color, defaultLightTheme, HUDINI_KEY, HudiniPlugin, HudiniPluginData, SceneWithHudini, TextButton } from 'hudini';
+  import { Color, defaultLightTheme, HUDINI_KEY, HudiniPlugin, HudiniPluginData, withHudini, TextButton } from 'hudini';
 
   const SOUND_KEYS = {
     MOUSE_HOVER: 'mouse-hover',
@@ -141,7 +141,7 @@ class GameScene extends Phaser.Scene {
     }
   };
 
-  class SoundStudioDemoScene extends SceneWithHudini {
+  class SoundStudioDemoScene extends Phaser.Scene {
     constructor() {
       super('sound-studio-demo');
     }
@@ -152,7 +152,8 @@ class GameScene extends Phaser.Scene {
     }
 
     create(): void {
-      this.cameras.main.setBackgroundColor(this.pw.color.rgb('slate-900'));
+      const { pw } = withHudini(this);
+      this.cameras.main.setBackgroundColor(pw.color.rgb('slate-900'));
 
       // Title
       this.add.text(400, 100, 'Phaser Sound Studio Demo', {

--- a/packages/showcase/src/pages/phaser-wind/button.astro
+++ b/packages/showcase/src/pages/phaser-wind/button.astro
@@ -32,21 +32,22 @@ import PhaserGame from '../../components/PhaserGame.astro';
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
       <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
-        <pre class="text-sm text-gray-100"><code>{`import {
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
   Color,
   type ColorToken,
   createTheme,
   PHASER_WIND_KEY,
   PhaserWindPlugin,
-  SceneWithPhaserWind,
+  withPhaserWind,
 } from 'phaser-wind';
 
 const theme = createTheme({});
 type Theme = typeof theme;
 
-class ButtonScene extends SceneWithPhaserWind<Theme> {
+class ButtonScene extends Phaser.Scene {
   create(): void {
-    const { pw } = this;
+    const pw = withPhaserWind<Theme>(this);
     this.cameras.main.setBackgroundColor(Color.slate(900));
 
     const createButton = (
@@ -151,19 +152,19 @@ class ButtonScene extends SceneWithPhaserWind<Theme> {
     createTheme,
     PHASER_WIND_KEY,
     PhaserWindPlugin,
-    SceneWithPhaserWind,
+    withPhaserWind,
   } from 'phaser-wind';
 
   const theme = createTheme({});
   type Theme = typeof theme;
 
-  class PhaserWindButtonScene extends SceneWithPhaserWind<Theme> {
+  class PhaserWindButtonScene extends Phaser.Scene {
     constructor() {
       super('phaser-wind-button');
     }
 
     create(): void {
-      const { pw } = this;
+      const pw = withPhaserWind<Theme>(this);
       this.cameras.main.setBackgroundColor(Color.slate(900));
 
       // Title


### PR DESCRIPTION
## Description

Introduces a `with*` accessor pattern to grab the plugin from a scene without forcing inheritance or global module augmentation, adds a new `Opacity` token to phaser-wind, and migrates the entire showcase to the new pattern (with syntax highlighting on code blocks as a bonus).

The old `SceneWithPhaserWind` / `SceneWithHudini` base classes stay exported and functional but are marked `@deprecated` — no runtime break for consumers.

## Type of Change

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [x] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [x] phaser-wind
- [x] hudini
- [ ] phaser-sound-studio
- [ ] phaser-data-studio
- [x] showcase
- [ ] virtual-joystick
- [ ] Other (please specify): ______

## Changes

### Added

- `withPhaserWind(scene)` accessor in `phaser-wind` — grabs the plugin from a scene, generic over the theme type. Composes with any base scene, no module augmentation, no non-null assertions.
- `withHudini(scene)` accessor in `hudini` — same pattern.
- `Opacity` token module in `phaser-wind` — Tailwind-style scale (`0, 5, 10, …, 95, 100`), mapped to Phaser's `setAlpha()` range (0..1). API mirrors `Spacing`/`Radius`: `Opacity.value('50')`, `Opacity.percent('50')`, `Opacity.css('50')`. Wired into `BaseThemeConfig` / `ThemeOverride` / `defaultLightTheme`, exposed on the plugin as `pw.opacity`.
- Syntax highlighting on all `<pre><code>` blocks in the showcase via `highlight.js` (CDN, atom-one-dark theme) — global, no per-page change.

### Changed

- Both READMEs (`phaser-wind` and `hudini`) now show only the `with*` accessor plus a recommended project-local helper (`withPw` / `withHud`) that wraps the generic once so scenes don't repeat `<ThemeType>` at every call site.
- All showcase pages migrated: `extends SceneWithHudini<Theme>` / `extends SceneWithPhaserWind<Theme>` → `extends Phaser.Scene` + `const pw = withPhaserWind<Theme>(this)` (or the hudini equivalent). Applies to both the runtime `<script>` blocks and the demo code inside `<pre>` samples.
- `install-base-scene.astro` narrative rewritten from "Base Scene Class" to "Accessor Hook".

### Removed

- The three old scene-typing sections in `phaser-wind`'s README (module augmentation / cast / inheritance). Only the new hook + project-local helper remain.
- All uses of the deprecated scene base classes in the showcase.

### Deprecated (kept exported for backwards compatibility)

- `SceneWithPhaserWind` — JSDoc `@deprecated` pointing to `withPhaserWind`, explaining the single-inheritance and lifecycle-assertion problems.
- `SceneWithHudini` — same treatment, pointing to `withHudini`.

## How to Test

1. `pnpm --filter phaser-wind test` — the new `Opacity` module ships with 8 tests covering `value`/`percent`/`css`, defaults, and theme overrides.
2. `pnpm --filter phaser-wind tsc --noEmit` and `pnpm --filter hudini tsc --noEmit` — should typecheck clean.
3. `pnpm --filter phaser-toolkit-showcase build` — should generate 31 pages without errors.
4. Open the built showcase locally and visit any code sample page (e.g. `/hudini/card`) — `<pre>` blocks should render with atom-one-dark syntax highlighting.
5. In any consumer of the deprecated classes, swap `class MyScene extends SceneWithPhaserWind<Theme>` for `class MyScene extends Phaser.Scene { create() { const pw = withPhaserWind<Theme>(this); ... } }` — behavior should be identical.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)