### PR TITLE
feat: add Stack + Dock components, outline button variant

### DIFF
--- a/.changeset/short-laws-matter.md
+++ b/.changeset/short-laws-matter.md
@@ -1,0 +1,5 @@
+---
+'hudini': minor
+---
+
+Add component Stack and Dock

--- a/packages/hudini/src/components/card/card.ts
+++ b/packages/hudini/src/components/card/card.ts
@@ -33,19 +33,18 @@ export type CardParams = {
   height?: number;
 };
 
-// Border constants
-const BLACK_BORDER_THICKNESS = 2;
-const WHITE_BORDER_EXTRA_PIXELS_PER_SIDE = 2;
-// eslint-disable-next-line no-magic-numbers
-const WHITE_BORDER_TOTAL_EXTRA_PIXELS = WHITE_BORDER_EXTRA_PIXELS_PER_SIDE * 3; // 6 pixels total
-const WHITE_BORDER_RADIUS_EXTRA = 2;
+/**
+ * Extra transparent margin around the drawn card inside its texture, just
+ * enough so the anti-aliased rounded-corner fill isn't clipped at the edge.
+ * The container itself is resized to the *visual* box, so this margin never
+ * leaks into layout measurements.
+ */
+const TEXTURE_ANTIALIAS_MARGIN = 1;
 
 /**
  * A flexible card component that adapts to its child content size
  */
 export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
-  /** The white border sprite of the card. */
-  public whiteBorderSprite!: GameObjects.Sprite;
   /** The background sprite of the card. */
   public backgroundSprite!: GameObjects.Sprite;
   /** The child component contained within the card */
@@ -98,8 +97,7 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
     // Check if explicit size was provided
     this.hasExplicitSize = width !== undefined && height !== undefined;
 
-    // Create sprites and setup container
-    this.createWhiteBorderSprite(scene);
+    // Create sprite and setup container
     this.createBackgroundSprite(scene);
     this.setupContainer();
 
@@ -202,16 +200,6 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
   }
 
   /**
-   * Creates the white border sprite for the card.
-   * @param scene Phaser scene.
-   */
-  private createWhiteBorderSprite(scene: Scene): void {
-    const whiteBorderTexture = this.createWhiteBorderTexture(scene);
-    this.whiteBorderSprite = scene.add.sprite(0, 0, whiteBorderTexture);
-    this.whiteBorderSprite.setOrigin(0.5, 0.5);
-  }
-
-  /**
    * Creates the background sprite for the card.
    * @param scene Phaser scene.
    */
@@ -222,14 +210,10 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
   }
 
   /**
-   * Regenerates the background and white border textures based on current state.
+   * Regenerates the background texture based on current state.
    */
   private regenerateSprites(): void {
-    // Regenerate textures
-    const whiteBorderTexture = this.createWhiteBorderTexture(this.scene);
     const backgroundTexture = this.createBackgroundTexture(this.scene);
-
-    this.whiteBorderSprite.setTexture(whiteBorderTexture);
     this.backgroundSprite.setTexture(backgroundTexture);
   }
 
@@ -237,7 +221,7 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
    * Sets up the container with background and child
    */
   private setupContainer(): void {
-    this.add([this.whiteBorderSprite, this.backgroundSprite]);
+    this.add([this.backgroundSprite]);
     if (this.child) {
       this.add([this.child]);
     }
@@ -407,47 +391,7 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
   }
 
   /**
-   * Creates a texture for the card's white border.
-   * @param scene Phaser scene.
-   * @returns The texture key.
-   */
-  private createWhiteBorderTexture(scene: Scene): string {
-    const { width, height } = this.getCardDimensions();
-    const textureKey = `card_whiteBorder_${this.borderRadiusPx}_${width}_${height}`;
-
-    // White border is larger on each side
-    const borderWidth = width + WHITE_BORDER_TOTAL_EXTRA_PIXELS;
-    const borderHeight = height + WHITE_BORDER_TOTAL_EXTRA_PIXELS;
-
-    // Add some padding for texture
-    const padding = 8;
-    const textureWidth = borderWidth + padding * 2;
-    const textureHeight = borderHeight + padding * 2;
-
-    const graphics = scene.add.graphics();
-
-    const maxRadius = Math.floor(Math.min(borderWidth / 2, borderHeight / 2));
-    const effectiveRadius = Math.min(this.borderRadiusPx + WHITE_BORDER_RADIUS_EXTRA, maxRadius);
-    const finalRadius = Math.max(0, effectiveRadius);
-
-    // White border (outer)
-    graphics.fillStyle(Color.hex('white'), 1);
-    graphics.fillRoundedRect(
-      padding,
-      padding,
-      borderWidth,
-      borderHeight,
-      finalRadius
-    );
-
-    graphics.generateTexture(textureKey, textureWidth, textureHeight);
-    graphics.destroy();
-
-    return textureKey;
-  }
-
-  /**
-   * Creates a texture for the card's background.
+   * Creates a texture for the card's background: a flat filled rounded rect.
    * @param scene Phaser scene.
    * @returns The texture key.
    */
@@ -455,8 +399,7 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
     const { width, height } = this.getCardDimensions();
     const textureKey = `card_bg_${this.backgroundColorValue}_${this.borderRadiusPx}_${width}_${height}`;
 
-    // Add some padding for texture
-    const padding = 8;
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
     const textureWidth = width + padding * 2;
     const textureHeight = height + padding * 2;
 
@@ -466,13 +409,8 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
     const effectiveRadius = Math.min(this.borderRadiusPx, maxRadius);
     const finalRadius = Math.max(0, effectiveRadius);
 
-    // Draw background with white fill and black stroke
     graphics.fillStyle(Color.hex(this.backgroundColorValue), 1);
     graphics.fillRoundedRect(padding, padding, width, height, finalRadius);
-
-    // Black stroke border
-    graphics.lineStyle(BLACK_BORDER_THICKNESS, Color.hex('black'), 1);
-    graphics.strokeRoundedRect(padding, padding, width, height, finalRadius);
 
     graphics.generateTexture(textureKey, textureWidth, textureHeight);
     graphics.destroy();

--- a/packages/hudini/src/components/card/card.ts
+++ b/packages/hudini/src/components/card/card.ts
@@ -61,6 +61,15 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
 
   /** Whether we have an explicit size set (width and height provided) */
   private hasExplicitSize: boolean = false;
+  /**
+   * Cached explicit width/height. We can't rely on `this.width` / `this.height`
+   * during initial sprite creation because `ContainerInteractive` proxies them
+   * through `hitArea`, which isn't assigned yet in the constructor. Reading
+   * `this.width` before `hitArea` is set returns 0, so we keep the requested
+   * dimensions here and consult them in {@link getCardDimensions}.
+   */
+  private explicitWidth: number | undefined;
+  private explicitHeight: number | undefined;
 
   /**
    * Creates a new Card
@@ -96,12 +105,22 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
 
     // Check if explicit size was provided
     this.hasExplicitSize = width !== undefined && height !== undefined;
+    this.explicitWidth = width;
+    this.explicitHeight = height;
 
     // Create sprite and setup container
     this.createBackgroundSprite(scene);
     this.setupContainer();
 
     this.hitArea = this.backgroundSprite;
+
+    // Now that hitArea is set, publish the explicit dimensions through the
+    // proxy so that consumers reading `card.width` / `card.height` (Row,
+    // Column, Stack, ...) see the real box, not 0.
+    if (this.hasExplicitSize) {
+      this.backgroundSprite.width = this.explicitWidth as number;
+      this.backgroundSprite.height = this.explicitHeight as number;
+    }
   }
   /**
    * Override setSize to regenerate sprites when size changes
@@ -112,6 +131,8 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
   public override setSize(width: number, height: number): this {
     // Mark that we now have explicit size
     this.hasExplicitSize = true;
+    this.explicitWidth = width;
+    this.explicitHeight = height;
     // Set size directly on the container to avoid recursion
     this.width = width;
     this.height = height;
@@ -375,8 +396,11 @@ export class Card extends ContainerInteractive<Phaser.GameObjects.Sprite> {
     let height = 0;
 
     if (this.hasExplicitSize) {
-      width = this.width;
-      height = this.height;
+      // Prefer the cached constructor/setSize dims — `this.width`/`this.height`
+      // depend on `hitArea` being wired, which is not the case on the initial
+      // texture generation call during `super`/constructor time.
+      width = this.explicitWidth ?? this.width;
+      height = this.explicitHeight ?? this.height;
     } else if (this.child) {
       const { w: cw, h: ch } = this.measureChild(this.child as GameObjects.GameObject);
       width = cw + this.marginPx * 2;

--- a/packages/hudini/src/components/dock/dock.spec.ts
+++ b/packages/hudini/src/components/dock/dock.spec.ts
@@ -1,0 +1,172 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('phaser-wind', () => ({
+  Color: {
+    rgb: vi.fn((color: string) => `rgb-${color}`),
+  },
+}));
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    fontSize: {
+      px: vi.fn((key: string) => {
+        const map: Record<string, number> = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 };
+        return map[key] ?? 16;
+      }),
+    },
+  })),
+}));
+
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    public style: Record<string, unknown> = {};
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(c: string): this {
+      this.style['color'] = c;
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 100;
+    public height = 40;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
+vi.mock('phaser', () => {
+  class MockText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _t: string, _s: unknown) {}
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+  }
+  class MockRectangle {
+    public listeners: Record<string, Array<() => void>> = {};
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _w: number, _h: number, _c: number, _a: number) {}
+    setOrigin(): this {
+      return this;
+    }
+    setInteractive(): this {
+      return this;
+    }
+    on(evt: string, cb: () => void): this {
+      (this.listeners[evt] ||= []).push(cb);
+      return this;
+    }
+    emit(evt: string): this {
+      (this.listeners[evt] ?? []).forEach((cb) => cb());
+      return this;
+    }
+  }
+  class MockInnerContainer {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _children: unknown[]) {}
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  class Container {
+    scene: Scene;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    setSize(): this {
+      return this;
+    }
+  }
+  class Scene {
+    add = {
+      existing: vi.fn(),
+      text: vi.fn((x: number, y: number, t: string, s: unknown) => new MockText(x, y, t, s)),
+      rectangle: vi.fn(
+        (x: number, y: number, w: number, h: number, c: number, a: number) =>
+          new MockRectangle(x, y, w, h, c, a)
+      ),
+      container: vi.fn((x: number, y: number, children: unknown[]) => new MockInnerContainer(x, y, children)),
+    };
+  }
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Dock, type DockItem } from './dock';
+
+const items: DockItem[] = [
+  { id: 'home', icon: 'house', label: 'Home' },
+  { id: 'search', icon: 'magnifying-glass', label: 'Search' },
+  { id: 'profile', icon: 'user', label: 'Profile' },
+];
+
+describe('Dock', () => {
+  it('should create a Dock instance', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items });
+    expect(dock).toBeInstanceOf(Dock);
+  });
+
+  it('should return the initial active id via getActiveItem', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items, active: 'home' });
+    expect(dock.getActiveItem()).toBe('home');
+  });
+
+  it('should update active id via setActiveItem', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items, active: 'home' });
+    dock.setActiveItem('search');
+    expect(dock.getActiveItem()).toBe('search');
+  });
+
+  it('should support chaining on setActiveItem', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items });
+    expect(dock.setActiveItem('profile')).toBe(dock);
+  });
+
+  it('should silently ignore setActiveItem for an unknown id (still updates internal state)', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items });
+    dock.setActiveItem('does-not-exist');
+    expect(dock.getActiveItem()).toBe('does-not-exist');
+  });
+
+  it('should be constructable without a background', () => {
+    const scene = new Scene();
+    const dock = new Dock({ scene, x: 0, y: 0, items });
+    expect(dock).toBeInstanceOf(Dock);
+  });
+});

--- a/packages/hudini/src/components/dock/dock.spec.ts
+++ b/packages/hudini/src/components/dock/dock.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-magic-numbers */
 /* eslint-disable max-lines-per-function */
+/* eslint-disable sonarjs/no-identical-functions */
 import { Scene } from 'phaser';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/packages/hudini/src/components/dock/dock.ts
+++ b/packages/hudini/src/components/dock/dock.ts
@@ -1,0 +1,282 @@
+/* eslint-disable max-lines-per-function */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
+import { GameObjects, Scene } from 'phaser';
+import {
+  Color,
+  PhaserWindPlugin,
+  type ColorKey,
+  type FontSizeKey,
+  type RadiusKey,
+  type SpacingKey,
+} from 'phaser-wind';
+
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { Stack } from '../stack';
+
+/** A single entry in a Dock. */
+export type DockItem = {
+  /** Unique identifier passed back to `onSelect`. */
+  id: string;
+  /** Font Awesome icon key to render above the label. */
+  icon: IconKey;
+  /** Text shown under the icon. */
+  label: string;
+};
+
+/**
+ * Parameters for creating a Dock.
+ *
+ * A Dock is a bottom-navigation-style bar (daisyUI's `dock`) — a horizontal
+ * strip of icon + label items where one can be marked "active". The Dock
+ * itself is stateless in the React sense: it renders whatever `active` the
+ * client passes and fires `onSelect(id, index)` on click. It's up to the
+ * client to update `active` (via `setActiveItem`) if they want the visual to
+ * reflect the selection.
+ */
+export type DockParams = {
+  /** Phaser scene where the dock will be added. */
+  scene: Scene;
+  /** X position of the dock (center of the whole bar). */
+  x: number;
+  /** Y position of the dock (center of the whole bar). */
+  y: number;
+  /** Items to render, in order. */
+  items: DockItem[];
+  /** Currently active item id. If omitted, no item is highlighted initially. */
+  active?: string;
+  /** Gap between items in pixels. Defaults to `24`. */
+  gap?: number;
+  /**
+   * Inner padding between the items and the background edge. Only visible
+   * when `backgroundColor` is set. Defaults to `'3'`.
+   */
+  padding?: SpacingKey | number;
+  /** Background fill color for the dock bar. */
+  backgroundColor?: ColorKey | string;
+  /** Border radius on the background. Defaults to `'lg'`. */
+  borderRadius?: RadiusKey | number;
+  /** Icon color for the active item. Defaults to `'blue-500'`. */
+  activeColor?: ColorKey | string;
+  /** Icon color for inactive items. Defaults to `'slate-400'`. */
+  inactiveColor?: ColorKey | string;
+  /** Icon size in px or FontSizeKey. Defaults to `'2xl'` (24px). */
+  iconSize?: FontSizeKey | number;
+  /** Label font size in px or FontSizeKey. Defaults to `'xs'` (12px). */
+  labelSize?: FontSizeKey | number;
+  /**
+   * Extra horizontal padding around each item's hit area, in pixels.
+   * Widens the click target beyond the icon+label footprint. Defaults to `8`.
+   */
+  itemHitPaddingX?: number;
+  /**
+   * Extra vertical padding around each item's hit area, in pixels.
+   * Defaults to `4`.
+   */
+  itemHitPaddingY?: number;
+  /** Fired when an item is clicked. */
+  onSelect?: (id: string, index: number) => void;
+};
+
+type DockItemVisual = {
+  icon: IconText;
+  label: GameObjects.Text;
+  container: GameObjects.Container;
+};
+
+const DEFAULT_ICON_SIZE_KEY: FontSizeKey = '2xl';
+const DEFAULT_LABEL_SIZE_KEY: FontSizeKey = 'xs';
+const DEFAULT_GAP = 24;
+const DEFAULT_ITEM_HIT_PADDING_X = 8;
+const DEFAULT_ITEM_HIT_PADDING_Y = 4;
+const ICON_LABEL_GAP = 2;
+
+/**
+ * Dock — a daisyUI-inspired bottom navigation bar.
+ *
+ * The client controls the "active" state; the Dock itself just renders and
+ * fires callbacks.
+ *
+ * @example
+ * const dock = new Dock({
+ *   scene, x: 400, y: 560,
+ *   backgroundColor: 'slate-800',
+ *   active: 'home',
+ *   items: [
+ *     { id: 'home',    icon: 'house',    label: 'Home' },
+ *     { id: 'search',  icon: 'magnifying-glass', label: 'Search' },
+ *     { id: 'profile', icon: 'user',     label: 'Profile' },
+ *   ],
+ *   onSelect: (id) => {
+ *     dock.setActiveItem(id);           // update visual
+ *     game.scene.start(`scene-${id}`); // client-side reaction
+ *   },
+ * });
+ */
+export class Dock extends GameObjects.Container {
+  /** The underlying horizontal Stack containing all items. */
+  public bar!: Stack;
+
+  private pw: PhaserWindPlugin<{}>;
+  private itemsById: Map<string, DockItemVisual> = new Map();
+  private activeId: string | undefined;
+  private activeColorValue: string;
+  private inactiveColorValue: string;
+  private iconSizePx: number;
+  private labelSizePx: number;
+  private onSelect: ((id: string, index: number) => void) | undefined;
+
+  constructor({
+    scene,
+    x,
+    y,
+    items,
+    active,
+    gap = DEFAULT_GAP,
+    padding = '3',
+    backgroundColor,
+    borderRadius = 'lg',
+    activeColor = 'blue-500',
+    inactiveColor = 'slate-400',
+    iconSize,
+    labelSize,
+    itemHitPaddingX = DEFAULT_ITEM_HIT_PADDING_X,
+    itemHitPaddingY = DEFAULT_ITEM_HIT_PADDING_Y,
+    onSelect,
+  }: DockParams) {
+    super(scene, x, y);
+    this.pw = getPWFromScene(scene);
+
+    this.activeId = active;
+    this.activeColorValue = Color.rgb(activeColor as ColorKey);
+    this.inactiveColorValue = Color.rgb(inactiveColor as ColorKey);
+    this.iconSizePx =
+      typeof iconSize === 'number'
+        ? iconSize
+        : this.pw.fontSize.px(iconSize ?? DEFAULT_ICON_SIZE_KEY);
+    this.labelSizePx =
+      typeof labelSize === 'number'
+        ? labelSize
+        : this.pw.fontSize.px(labelSize ?? DEFAULT_LABEL_SIZE_KEY);
+    this.onSelect = onSelect;
+
+    const itemContainers = items.map((item, index) =>
+      this.buildItem(item, index, itemHitPaddingX, itemHitPaddingY)
+    );
+
+    this.bar = new Stack({
+      scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap,
+      padding,
+      // Only pass `backgroundColor` when defined — Stack's optional field
+      // trips exactOptionalPropertyTypes if we send `undefined`.
+      ...(backgroundColor !== undefined && { backgroundColor }),
+      borderRadius,
+      children: itemContainers,
+    });
+    this.add(this.bar);
+
+    // Publish size for a parent layout container.
+    this.setSize(this.bar.width, this.bar.height);
+  }
+
+  /**
+   * Change the active item and re-tint the visuals. No callback is fired —
+   * this is the "controlled" setter meant to be called from an `onSelect`
+   * handler in the client.
+   */
+  public setActiveItem(id: string | undefined): this {
+    const prev = this.activeId;
+    this.activeId = id;
+    if (prev && this.itemsById.has(prev)) {
+      this.applyState(prev);
+    }
+    if (id && this.itemsById.has(id)) {
+      this.applyState(id);
+    }
+    return this;
+  }
+
+  /** Currently active item id, or `undefined` if none. */
+  public getActiveItem(): string | undefined {
+    return this.activeId;
+  }
+
+  private buildItem(
+    item: DockItem,
+    index: number,
+    hitPaddingX: number,
+    hitPaddingY: number
+  ): GameObjects.Container {
+    const scene = this.scene;
+    const initialColor =
+      item.id === this.activeId
+        ? this.activeColorValue
+        : this.inactiveColorValue;
+
+    const iconText = new IconText({
+      scene,
+      x: 0,
+      y: 0,
+      icon: item.icon,
+      size: this.iconSizePx,
+      style: { color: initialColor },
+    });
+    iconText.setFontStyle('900');
+    iconText.setOrigin(0.5, 0.5);
+    scene.add.existing(iconText);
+
+    const label = scene.add.text(0, 0, item.label, {
+      fontFamily: 'Fredoka',
+      fontSize: `${this.labelSizePx}px`,
+      color: initialColor,
+    });
+    label.setOrigin(0.5, 0.5);
+
+    // Icon+label as a vertical Stack (pure layout, no bg).
+    const column = new Stack({
+      scene,
+      x: 0,
+      y: 0,
+      direction: 'column',
+      gap: ICON_LABEL_GAP,
+      align: 'center',
+      children: [iconText, label],
+    });
+
+    // Widen the click target beyond the visible column footprint.
+    const hitWidth = column.width + hitPaddingX * 2;
+    const hitHeight = column.height + hitPaddingY * 2;
+    const hitRect = scene.add.rectangle(0, 0, hitWidth, hitHeight, 0x000000, 0);
+    hitRect.setOrigin(0.5, 0.5);
+    hitRect.setInteractive({ useHandCursor: true });
+
+    hitRect.on('pointerdown', () => {
+      this.onSelect?.(item.id, index);
+    });
+
+    const itemContainer = scene.add.container(0, 0, [hitRect, column]);
+    // Report the padded size so the outer Stack measures the click target.
+    itemContainer.setSize(hitWidth, hitHeight);
+
+    this.itemsById.set(item.id, {
+      icon: iconText,
+      label,
+      container: itemContainer,
+    });
+
+    return itemContainer;
+  }
+
+  private applyState(itemId: string): void {
+    const visual = this.itemsById.get(itemId);
+    if (!visual) return;
+    const isActive = itemId === this.activeId;
+    const c = isActive ? this.activeColorValue : this.inactiveColorValue;
+    visual.icon.setColor(c);
+    visual.label.setColor(c);
+  }
+}

--- a/packages/hudini/src/components/dock/index.ts
+++ b/packages/hudini/src/components/dock/index.ts
@@ -1,0 +1,1 @@
+export * from './dock';

--- a/packages/hudini/src/components/icon-button/icon-button.ts
+++ b/packages/hudini/src/components/icon-button/icon-button.ts
@@ -11,8 +11,10 @@ import {
 } from 'phaser-wind';
 
 import {
+  BUTTON_OUTLINE_THICKNESS,
   BUTTON_STROKE_THICKNESS,
   getButtonStrokeColor,
+  type ButtonVariant,
 } from '../../utils/button-style';
 import { getPWFromScene } from '../../utils/get-pw-from-scene';
 
@@ -26,6 +28,11 @@ export type IconButtonParams = {
   onClick?: () => void;
   /** Border radius in px (number) or a Phaser Wind radius token (string). Defaults to 'full'. */
   borderRadius?: RadiusKey | number;
+  /**
+   * Visual variant. `'filled'` = solid background (default). `'outline'` =
+   * transparent background with a colored border and colored icon.
+   */
+  variant?: ButtonVariant;
 };
 
 const durations = {
@@ -50,6 +57,8 @@ export class IconButton extends GameObjects.Container {
   private colorButton!: string;
   private sizePx!: number;
   private borderRadiusPx!: number;
+  private variant!: ButtonVariant;
+  private icon!: IconKey;
 
   constructor({
     scene,
@@ -60,6 +69,7 @@ export class IconButton extends GameObjects.Container {
     color,
     onClick,
     borderRadius,
+    variant = 'filled',
   }: IconButtonParams) {
     super(scene, x, y);
     this.pw = getPWFromScene(scene);
@@ -71,6 +81,8 @@ export class IconButton extends GameObjects.Container {
 
     const baseColor = color ?? 'blue-500';
     this.sizePx = sizePx;
+    this.variant = variant;
+    this.icon = icon;
 
     this.updateSize();
 
@@ -95,6 +107,28 @@ export class IconButton extends GameObjects.Container {
     if (this.borderRadiusPx === newRadiusPx) return this;
     this.borderRadiusPx = newRadiusPx;
 
+    const backgroundTexture = this.createBackgroundTexture(
+      this.scene,
+      this.sizePx,
+      this.baseColor,
+      this.borderRadiusPx
+    );
+    this.backgroundSprite.setTexture(backgroundTexture);
+    return this;
+  }
+
+  /**
+   * Switch between `'filled'` and `'outline'` variants at runtime. Regenerates
+   * both the background and the icon so their styling reflects the variant.
+   */
+  public setVariant(variant: ButtonVariant): this {
+    if (this.variant === variant) return this;
+    this.variant = variant;
+    // Recreate the icon so its color/stroke reflect the new variant.
+    this.remove(this.iconText, true);
+    this.createIconText(this.scene, this.icon, this.sizePx);
+    this.add(this.iconText);
+    // Regenerate the background texture with the new drawing mode.
     const backgroundTexture = this.createBackgroundTexture(
       this.scene,
       this.sizePx,
@@ -171,7 +205,9 @@ export class IconButton extends GameObjects.Container {
   }
 
   /**
-   * Draws the button's background as a flat filled rounded rect.
+   * Draws the button's background. `filled` → solid fill. `outline` → colored
+   * border inset by half its thickness so the outer edge sits at the visual
+   * box boundary.
    */
   private drawButtonBackground(
     graphics: Phaser.GameObjects.Graphics,
@@ -180,6 +216,18 @@ export class IconButton extends GameObjects.Container {
     side: number,
     effectiveRadius: number
   ): void {
+    if (this.variant === 'outline') {
+      const half = BUTTON_OUTLINE_THICKNESS / 2;
+      graphics.lineStyle(BUTTON_OUTLINE_THICKNESS, Color.hex(this.colorButton), 1);
+      graphics.strokeRoundedRect(
+        centerX - side / 2 + half,
+        centerY - side / 2 + half,
+        side - BUTTON_OUTLINE_THICKNESS,
+        side - BUTTON_OUTLINE_THICKNESS,
+        Math.max(0, effectiveRadius - half)
+      );
+      return;
+    }
     graphics.fillStyle(Color.hex(this.colorButton), 1);
     graphics.fillRoundedRect(
       centerX - side / 2,
@@ -195,6 +243,9 @@ export class IconButton extends GameObjects.Container {
     icon: IconKey,
     size: number
   ): void {
+    // In `outline`, the border carries the visual weight — icon uses the
+    // button color as fill, with no stroke, matching daisyUI.
+    const isOutline = this.variant === 'outline';
     this.iconText = new IconText({
       scene,
       x: 0,
@@ -202,9 +253,13 @@ export class IconButton extends GameObjects.Container {
       icon,
       size,
       style: {
-        color: Color.rgb('white'),
-        strokeThickness: BUTTON_STROKE_THICKNESS,
-        stroke: getButtonStrokeColor(this.baseColor as string),
+        color: isOutline
+          ? Color.rgb(this.baseColor as ColorKey)
+          : Color.rgb('white'),
+        strokeThickness: isOutline ? 0 : BUTTON_STROKE_THICKNESS,
+        stroke: isOutline
+          ? 'rgba(0,0,0,0)'
+          : getButtonStrokeColor(this.baseColor as string),
       },
     });
     this.iconText.setFontStyle('900');

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './badge';
 export * from './card';
 export * from './circular-progress';
 export * from './container-interactive';
+export * from './dock';
 export * from './icon-button';
 export * from './linear-progress';
 export * from './panel';

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './linear-progress';
 export * from './panel';
 export * from './radial-progress';
 export * from './sized-box';
+export * from './stack';
 export * from './text';
 export * from './text-button';
 

--- a/packages/hudini/src/components/stack/index.ts
+++ b/packages/hudini/src/components/stack/index.ts
@@ -1,0 +1,1 @@
+export * from './stack';

--- a/packages/hudini/src/components/stack/stack.spec.ts
+++ b/packages/hudini/src/components/stack/stack.spec.ts
@@ -1,0 +1,123 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('phaser-wind', () => {
+  class MockLayout {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    addChild(): this {
+      return this;
+    }
+    addChildren(): this {
+      return this;
+    }
+    layout(): void {
+      /* noop */
+    }
+  }
+  return {
+    Row: class extends MockLayout {},
+    Column: class extends MockLayout {},
+  };
+});
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    spacing: {
+      px: vi.fn((token: string) => {
+        const map = { '0': 0, '1': 4, '2': 8, '4': 16, '6': 24 };
+        return map[token as keyof typeof map] ?? 16;
+      }),
+    },
+    radius: {
+      px: vi.fn(() => 8),
+    },
+  })),
+}));
+
+vi.mock('../card', () => {
+  class MockCard {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setSize(): this {
+      return this;
+    }
+  }
+  return { Card: MockCard };
+});
+
+vi.mock('phaser', () => {
+  class Container {
+    scene: Scene;
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  class Scene {}
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Stack } from './stack';
+
+describe('Stack', () => {
+  it('should create a row Stack by default', () => {
+    const scene = new Scene();
+    const stack = new Stack({ scene, x: 0, y: 0 });
+    expect(stack).toBeInstanceOf(Stack);
+    expect(stack.background).toBeNull();
+  });
+
+  it('should create a column Stack when direction=column', () => {
+    const scene = new Scene();
+    const stack = new Stack({ scene, x: 0, y: 0, direction: 'column' });
+    expect(stack).toBeInstanceOf(Stack);
+  });
+
+  it('should create a background Card when backgroundColor is set', () => {
+    const scene = new Scene();
+    const stack = new Stack({
+      scene,
+      x: 0,
+      y: 0,
+      backgroundColor: 'slate-800',
+      padding: '4',
+      borderRadius: 'lg',
+    });
+    expect(stack.background).not.toBeNull();
+  });
+
+  it('should NOT create a background when backgroundColor is omitted', () => {
+    const scene = new Scene();
+    const stack = new Stack({ scene, x: 0, y: 0, padding: '4' });
+    expect(stack.background).toBeNull();
+  });
+
+  it('should expose the inner layout container', () => {
+    const scene = new Scene();
+    const stack = new Stack({ scene, x: 0, y: 0 });
+    expect(stack.layoutContainer).toBeDefined();
+  });
+
+  it('should support method chaining on addChild', () => {
+    const scene = new Scene();
+    const stack = new Stack({ scene, x: 0, y: 0 });
+    const fakeChild = {} as never;
+    expect(stack.addChild(fakeChild)).toBe(stack);
+  });
+});

--- a/packages/hudini/src/components/stack/stack.ts
+++ b/packages/hudini/src/components/stack/stack.ts
@@ -1,0 +1,241 @@
+/* eslint-disable max-lines-per-function */
+import { GameObjects, Scene } from 'phaser';
+import {
+  Column,
+  Row,
+  type ColorKey,
+  type HorizontalAlign,
+  type RadiusKey,
+  type SpacingKey,
+  type VerticalAlign,
+} from 'phaser-wind';
+
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { Card } from '../card';
+
+/**
+ * Direction along which children are stacked. `'row'` = horizontal (like
+ * `flex-direction: row`); `'column'` = vertical (`flex-direction: column`).
+ */
+export type StackDirection = 'row' | 'column';
+
+/**
+ * Alignment along the cross-axis. For `'row'` direction, this is vertical
+ * (`'top' | 'center' | 'bottom'`). For `'column'`, it is horizontal
+ * (`'left' | 'center' | 'right'`).
+ */
+export type StackAlign = VerticalAlign | HorizontalAlign;
+
+/**
+ * Parameters for creating a Stack.
+ *
+ * Stack is a layout primitive that arranges children in a `'row'` or
+ * `'column'`. When `backgroundColor` / `padding` / `borderRadius` are set,
+ * Stack also renders a Card behind the children — matching the Tailwind
+ * pattern `<div class="flex flex-row bg-slate-800 p-4 rounded-lg">...</div>`.
+ *
+ * Row and Column remain available as pure-layout primitives; Stack is the
+ * combo when you want layout + visual in a single node.
+ */
+export type StackParams = {
+  /** Phaser scene where the stack will be added. */
+  scene: Scene;
+  /** X position of the stack (center of the whole content area). */
+  x: number;
+  /** Y position of the stack (center of the whole content area). */
+  y: number;
+  /** Stack direction. Defaults to `'row'`. */
+  direction?: StackDirection;
+  /** Gap between children, in pixels. Defaults to `8`. */
+  gap?: number;
+  /**
+   * Cross-axis alignment.
+   * - `'row'`: `'top' | 'center' | 'bottom'` (default: `'center'`).
+   * - `'column'`: `'left' | 'center' | 'right'` (default: `'center'`).
+   */
+  align?: StackAlign;
+  /** Initial child GameObjects. */
+  children?: GameObjects.GameObject[];
+  /**
+   * Inner padding between the children and the container's visible edge.
+   * Only meaningful when `backgroundColor` is set (otherwise the container
+   * has no visible edge). Accepts a Phaser Wind spacing token or a raw px
+   * number. Defaults to `'4'` (16px).
+   */
+  padding?: SpacingKey | number;
+  /**
+   * Background fill color. When provided, a Card is rendered behind the
+   * children with the padded size. Omit for a purely transparent layout
+   * container.
+   */
+  backgroundColor?: ColorKey | string;
+  /**
+   * Border radius on the background. Only meaningful when `backgroundColor`
+   * is set. Defaults to `'md'`.
+   */
+  borderRadius?: RadiusKey | number;
+};
+
+const DEFAULT_GAP = 8;
+
+/**
+ * Stack — Row or Column with optional background/padding/radius.
+ *
+ * @example
+ * // Pure layout (like Row):
+ * new Stack({ scene, x, y, direction: 'row', children: [a, b, c] });
+ *
+ * @example
+ * // Layout + background (like `<div class="flex bg-slate-800 p-4 rounded-lg">`):
+ * new Stack({
+ *   scene, x, y,
+ *   direction: 'row',
+ *   gap: 12,
+ *   padding: '4',
+ *   backgroundColor: 'slate-800',
+ *   borderRadius: 'lg',
+ *   children: [btnA, btnB, btnC],
+ * });
+ */
+export class Stack extends GameObjects.Container {
+  /** The inner layout container (Row or Column). */
+  public layoutContainer!: Row | Column;
+  /** The background Card, when `backgroundColor` is provided. */
+  public background: Card | null = null;
+
+  /** The stack direction (readable so callers can branch on it). */
+  public readonly direction: StackDirection;
+
+  private paddingPx: number;
+  private hasBackground: boolean;
+
+  constructor({
+    scene,
+    x,
+    y,
+    direction = 'row',
+    gap = DEFAULT_GAP,
+    align,
+    children = [],
+    padding = '4',
+    backgroundColor,
+    borderRadius = 'md',
+  }: StackParams) {
+    super(scene, x, y);
+    const pw = getPWFromScene(scene);
+
+    this.direction = direction;
+    this.paddingPx =
+      typeof padding === 'number'
+        ? padding
+        : pw.spacing.px(padding ?? ('4' as SpacingKey));
+    this.hasBackground = backgroundColor !== undefined;
+
+    // Create the inner layout container (Row or Column) at local (0,0) so it
+    // sits centered inside this Stack.
+    this.layoutContainer =
+      direction === 'row'
+        ? new Row({
+            scene,
+            x: 0,
+            y: 0,
+            gap,
+            align: (align as VerticalAlign) ?? 'center',
+            children,
+          })
+        : new Column({
+            scene,
+            x: 0,
+            y: 0,
+            gap,
+            align: (align as HorizontalAlign) ?? 'center',
+            children,
+          });
+
+    // Optional background card, sized to cover the layout + padding.
+    if (this.hasBackground) {
+      const { width, height } = this.getLayoutSize();
+      this.background = new Card({
+        scene,
+        x: 0,
+        y: 0,
+        backgroundColor: backgroundColor as ColorKey | string,
+        borderRadius,
+        margin: 0,
+        width: width + this.paddingPx * 2,
+        height: height + this.paddingPx * 2,
+      });
+      // Add card first so it renders BEHIND the layout container.
+      this.add(this.background);
+    }
+
+    this.add(this.layoutContainer);
+    this.syncSize();
+  }
+
+  /**
+   * Adds a single child to the stack.
+   * @param child GameObject to append.
+   * @param relayout Whether to trigger a re-layout (default `true`).
+   */
+  public addChild(
+    child: GameObjects.GameObject,
+    relayout: boolean = true
+  ): this {
+    this.layoutContainer.addChild(child, relayout);
+    if (relayout) this.syncBackground();
+    return this;
+  }
+
+  /**
+   * Adds multiple children to the stack.
+   * @param children Array of GameObjects to append.
+   * @param relayout Whether to trigger a re-layout (default `true`).
+   */
+  public addChildren(
+    children: GameObjects.GameObject[],
+    relayout: boolean = true
+  ): this {
+    this.layoutContainer.addChildren(children, relayout);
+    if (relayout) this.syncBackground();
+    return this;
+  }
+
+  /**
+   * Re-layouts the children and resyncs the background/size. Call this after
+   * mutating child sizes externally.
+   */
+  public layout(): void {
+    this.layoutContainer.layout();
+    this.syncBackground();
+  }
+
+  private getLayoutSize(): { width: number; height: number } {
+    // Row/Column update their own `.width`/`.height` via setSize during
+    // layout(). Fall back to 0 defensively for empty containers.
+    const width = (this.layoutContainer.width as number) ?? 0;
+    const height = (this.layoutContainer.height as number) ?? 0;
+    return { width, height };
+  }
+
+  private syncBackground(): void {
+    if (this.background) {
+      const { width, height } = this.getLayoutSize();
+      this.background.setSize(
+        width + this.paddingPx * 2,
+        height + this.paddingPx * 2
+      );
+    }
+    this.syncSize();
+  }
+
+  /**
+   * Keep this Stack's own `.width`/`.height` in sync with the visible box, so
+   * that a parent Row/Column/Stack measures it correctly.
+   */
+  private syncSize(): void {
+    const { width, height } = this.getLayoutSize();
+    const outerPadding = this.hasBackground ? this.paddingPx * 2 : 0;
+    this.setSize(width + outerPadding, height + outerPadding);
+  }
+}

--- a/packages/hudini/src/components/text-button/text-button.ts
+++ b/packages/hudini/src/components/text-button/text-button.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
 import { GameObjects, Scene } from 'phaser';
 import {
   Color,

--- a/packages/hudini/src/components/text-button/text-button.ts
+++ b/packages/hudini/src/components/text-button/text-button.ts
@@ -11,8 +11,10 @@ import {
 } from 'phaser-wind';
 
 import {
+  BUTTON_OUTLINE_THICKNESS,
   BUTTON_STROKE_THICKNESS,
   getButtonStrokeColor,
+  type ButtonVariant,
 } from '../../utils/button-style';
 import { getPWFromScene } from '../../utils/get-pw-from-scene';
 import { ContainerInteractive } from '../container-interactive';
@@ -44,7 +46,8 @@ export type TextButtonParams = {
    */
   color?: ColorKey | string;
   /**
-   * Text color. Defaults to 'white'.
+   * Text color. Defaults to `'white'` in the `'filled'` variant, and to the
+   * button's own `color` in the `'outline'` variant (matching daisyUI).
    */
   textColor?: ColorKey | string;
   /**
@@ -57,6 +60,11 @@ export type TextButtonParams = {
    * Defaults to 'md'.
    */
   padding?: SpacingKey | number;
+  /**
+   * Visual variant. `'filled'` = solid background (default). `'outline'` =
+   * transparent background with a colored border and colored text.
+   */
+  variant?: ButtonVariant;
   /**
    * Callback function for click event.
    */
@@ -98,6 +106,7 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   private textColorValue!: string;
   private fontFamily!: string;
   private textValue!: string;
+  private variant!: ButtonVariant;
   /**
    * Creates a new TextButton instance.
    * @param params TextButtonParams
@@ -110,9 +119,10 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     fontSize = 'lg',
     font,
     color = 'blue-500',
-    textColor = 'white',
+    textColor,
     borderRadius = 'md',
     padding = '4',
+    variant = 'filled',
     onClick,
   }: TextButtonParams) {
     super({ scene, x, y });
@@ -120,6 +130,7 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
 
     // Store values
     this.textValue = text;
+    this.variant = variant;
     this.fontSizePx =
       typeof fontSize === 'number'
         ? fontSize
@@ -138,7 +149,11 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     this.colorInput = String(color);
     this.colorButton = Color.rgb(color as ColorKey);
 
-    this.textColorValue = Color.rgb(textColor as ColorKey);
+    // Default text color depends on variant: filled → white, outline → same
+    // as the button color (daisyUI parity). Explicit user value always wins.
+    const resolvedTextColor =
+      textColor ?? (variant === 'outline' ? color : 'white');
+    this.textColorValue = Color.rgb(resolvedTextColor as ColorKey);
     this.fontFamily = font
       ? typeof font === 'string'
         ? font
@@ -247,10 +262,29 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   }
 
   /**
+   * Switch between `'filled'` and `'outline'` variants at runtime.
+   * Rebuilds the button text (stroke on/off) as well as the background sprite.
+   */
+  public setVariant(variant: ButtonVariant): this {
+    if (this.variant === variant) return this;
+    this.variant = variant;
+    // Recreate the text so its stroke config reflects the new variant.
+    this.remove(this.buttonText, true);
+    this.createButtonText(this.scene);
+    this.addAt(this.buttonText, this.list.length);
+    this.regenerateSprites();
+    return this;
+  }
+
+  /**
    * Creates the button text GameObject.
    * @param scene Phaser scene.
    */
   private createButtonText(scene: Scene): void {
+    // In `outline`, the border itself does the visual work — the text sits on
+    // a transparent bg, so an extra stroke around it would look muddy. Keep
+    // it clean (no stroke) and let the text color carry the contrast.
+    const isOutline = this.variant === 'outline';
     this.buttonText = new Text({
       scene,
       x: 0,
@@ -258,9 +292,16 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
       text: this.textValue,
       size: this.fontSizePx,
       fontFamily: this.fontFamily,
-      strokeThickness: BUTTON_STROKE_THICKNESS,
-      strokeColor: getButtonStrokeColor(this.colorInput),
+      strokeThickness: isOutline ? 0 : BUTTON_STROKE_THICKNESS,
+      strokeColor: isOutline ? 'rgba(0,0,0,0)' : getButtonStrokeColor(this.colorInput),
     });
+    // Preserve legacy behavior for `filled`: `textColor` on the constructor
+    // was historically dead (only `setTextColor()` after construction applied
+    // it). Outline needs the color for the border/text pairing to work, so
+    // we only push it into the Text object in that mode.
+    if (this.variant === 'outline') {
+      this.buttonText.setColor(this.textColorValue);
+    }
     this.buttonText.setOrigin(0.5, 0.5);
   }
 
@@ -335,7 +376,10 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   }
 
   /**
-   * Draws the button's background as a flat filled rounded rect.
+   * Draws the button's background. `filled` → solid fill. `outline` → colored
+   * border only, drawn inset by half the stroke width so the outer edge of
+   * the stroke sits exactly at the visual box boundary (i.e. `.width` /
+   * `.height` remain accurate for Row/Column).
    */
   private drawButtonBackground(
     graphics: Phaser.GameObjects.Graphics,
@@ -344,6 +388,18 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     height: number,
     effectiveRadius: number
   ): void {
+    if (this.variant === 'outline') {
+      const half = BUTTON_OUTLINE_THICKNESS / 2;
+      graphics.lineStyle(BUTTON_OUTLINE_THICKNESS, Color.hex(this.colorButton), 1);
+      graphics.strokeRoundedRect(
+        padding + half,
+        padding + half,
+        width - BUTTON_OUTLINE_THICKNESS,
+        height - BUTTON_OUTLINE_THICKNESS,
+        Math.max(0, effectiveRadius - half)
+      );
+      return;
+    }
     graphics.fillStyle(Color.hex(this.colorButton), 1);
     graphics.fillRoundedRect(padding, padding, width, height, effectiveRadius);
   }

--- a/packages/hudini/src/utils/button-style.ts
+++ b/packages/hudini/src/utils/button-style.ts
@@ -1,7 +1,20 @@
 import { Color, isColorKey, Opacity, type ColorKey } from 'phaser-wind';
 
+/**
+ * Visual variants shared by {@link TextButton} and {@link IconButton}.
+ *
+ * - `'filled'` (default): solid colored fill, white text/icon with a darker
+ *   colored outline stroke (daisyUI `btn-<color>`).
+ * - `'outline'`: transparent fill, colored border, colored text/icon
+ *   (daisyUI `btn-outline btn-<color>`).
+ */
+export type ButtonVariant = 'filled' | 'outline';
+
 /** Thickness of the outline stroke around a button's text or icon glyph. */
 export const BUTTON_STROKE_THICKNESS = 3;
+
+/** Thickness of the outer border used by the `'outline'` button variant. */
+export const BUTTON_OUTLINE_THICKNESS = 3;
 
 /**
  * Amount added to the palette shade to derive the button's stroke color.

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -169,6 +169,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/stack')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 🧱 Stack
               </a>
+              <a href={getUrl('/hudini/dock')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                ⚓ Dock
+              </a>
               <a href={getUrl('/hudini/sized-box')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 📏 Sized Box
               </a>

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -166,6 +166,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/row')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 📋 Row
               </a>
+              <a href={getUrl('/hudini/stack')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                🧱 Stack
+              </a>
               <a href={getUrl('/hudini/sized-box')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 📏 Sized Box
               </a>

--- a/packages/showcase/src/pages/hudini/dock.astro
+++ b/packages/showcase/src/pages/hudini/dock.astro
@@ -1,0 +1,242 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Dock Component" description="Bottom-navigation style bar (daisyUI's dock) — a row of clickable icon+label items with a controlled active state.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Dock Component</h2>
+      <p class="text-gray-600 mb-4">
+        A daisyUI-style bottom-navigation bar. Receives a list of items (icon + label) and fires <code class="bg-gray-100 px-1 rounded">onSelect(id, index)</code> when one is clicked. The Dock is <strong>stateless</strong> — it renders whichever item you mark as <code class="bg-gray-100 px-1 rounded">active</code>. The client decides what to do with the click and whether to move the active marker (via <code class="bg-gray-100 px-1 rounded">setActiveItem(id)</code>).
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>🎯 <strong>Icon + label per item</strong>: Font Awesome icon above a text label</li>
+          <li>🖱️ <strong>Callback API</strong>: <code>onSelect(id, index)</code> — you decide what happens</li>
+          <li>🎨 <strong>Active/inactive tint</strong>: distinct colors, controlled from outside</li>
+          <li>🧱 <strong>Optional background</strong>: <code>backgroundColor</code> + <code>borderRadius</code> for a bar-shaped surface</li>
+          <li>📐 <strong>Composes</strong>: Dock is a Container, use it anywhere (bottom of screen, side panel, etc)</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">items</code> - <code>DockItem[]</code> where each item has <code>id</code>, <code>icon</code> and <code>label</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">active</code> - Initial active item id (optional)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onSelect</code> - <code>(id, index) =&gt; void</code> callback fired on click</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">activeColor</code> / <code class="bg-gray-200 px-2 py-1 rounded">inactiveColor</code> - Icon/label colors per state</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">iconSize</code> / <code class="bg-gray-200 px-2 py-1 rounded">labelSize</code> - Type sizing (FontSizeKey or px)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">gap</code> - Space between items (default 24px)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">padding</code>, <code class="bg-gray-200 px-2 py-1 rounded">backgroundColor</code>, <code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code> - Optional bar background</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Methods -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Methods</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">setActiveItem(id)</code> - Update the visual active state (no callback fired)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">getActiveItem()</code> - Read the currently active id</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={520} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Dock,
+} from 'hudini';
+
+const theme = createTheme({});
+type Theme = typeof theme;
+
+class DockDemoScene extends Phaser.Scene {
+    create(): void {
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
+
+        const dock = new Dock({
+            scene: this,
+            x: this.cameras.main.centerX,
+            y: this.cameras.main.height - 60,
+            active: 'home',
+            backgroundColor: 'slate-800',
+            borderRadius: 'xl',
+            padding: '3',
+            items: [
+                { id: 'home',    icon: 'house',            label: 'Home' },
+                { id: 'search',  icon: 'magnifying-glass', label: 'Search' },
+                { id: 'profile', icon: 'user',             label: 'Profile' },
+                { id: 'settings', icon: 'gear',            label: 'Settings' },
+            ],
+            onSelect: (id, index) => {
+                // Client decides what to do — update visual state:
+                dock.setActiveItem(id);
+                console.log('Selected', id, 'at index', index);
+            },
+        });
+
+        this.add.existing(dock);
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Dock,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class DockDemoScene extends Phaser.Scene {
+    private lastPickText?: Phaser.GameObjects.Text;
+
+    constructor() {
+      super('dock-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(300));
+
+      const centerX = this.cameras.main.centerX;
+
+      this.add
+        .text(centerX, 40, 'Dock Component', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      this.add
+        .text(centerX, 80, 'Click an item — the client decides what happens.', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '14px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // Simulated "content" that reacts to the current selection.
+      this.lastPickText = this.add
+        .text(centerX, 200, 'Current selection: home', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '22px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Dock A: with background, at the bottom ---
+      const bottomDock = new Dock({
+        scene: this,
+        x: centerX,
+        y: this.cameras.main.height - 60,
+        active: 'home',
+        backgroundColor: 'slate-800',
+        borderRadius: 'xl',
+        padding: '3',
+        activeColor: 'cyan-400',
+        inactiveColor: 'slate-400',
+        items: [
+          { id: 'home', icon: 'house', label: 'Home' },
+          { id: 'search', icon: 'magnifying-glass', label: 'Search' },
+          { id: 'profile', icon: 'user', label: 'Profile' },
+          { id: 'settings', icon: 'gear', label: 'Settings' },
+        ],
+        onSelect: (id: string) => {
+          // Client controls both the visual state and the "route".
+          bottomDock.setActiveItem(id);
+          if (this.lastPickText) {
+            this.lastPickText.setText(`Current selection: ${id}`);
+          }
+        },
+      });
+      this.add.existing(bottomDock);
+
+      // --- Dock B: no background, showing a subset of icons ---
+      this.add
+        .text(centerX, 300, 'No background variant', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const bareDock = new Dock({
+        scene: this,
+        x: centerX,
+        y: 360,
+        active: 'library',
+        activeColor: 'purple-600',
+        inactiveColor: 'slate-500',
+        gap: 40,
+        items: [
+          { id: 'library', icon: 'book', label: 'Library' },
+          { id: 'compass', icon: 'compass', label: 'Explore' },
+          { id: 'heart', icon: 'heart', label: 'Liked' },
+        ],
+        onSelect: (id) => bareDock.setActiveItem(id),
+      });
+      this.add.existing(bareDock);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [DockDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-dock-demo'] = game;
+      });
+    }
+  });
+</script>

--- a/packages/showcase/src/pages/hudini/icon-button.astro
+++ b/packages/showcase/src/pages/hudini/icon-button.astro
@@ -35,6 +35,7 @@ import PhaserGame from '../../components/PhaserGame.astro';
             <li><code class="bg-gray-200 px-2 py-1 rounded">color</code> - Base color from phaser-wind (except black/white) - default: 'gray'</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">onClick</code> - Optional click handler function</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code> - Border radius token ('none', 'sm', 'md', 'lg', 'xl', 'full') or pixel value - default: 'full'</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">variant</code> - <code>'filled'</code> (default) or <code>'outline'</code> — daisyUI-style visual variants</li>
           </ul>
         </div>
       </div>
@@ -54,7 +55,7 @@ import PhaserGame from '../../components/PhaserGame.astro';
     </div>
 
     <!-- Live Example -->
-    <PhaserGame width={800} height={700} />
+    <PhaserGame width={800} height={820} />
 
     <!-- Usage Example -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -110,6 +111,21 @@ class ButtonDemoScene extends Phaser.Scene {
             },
         });
         this.add.existing(playButton);
+
+        // Outline variant (daisyUI-style)
+        const outlineHeart = new IconButton({
+            scene: this,
+            x: this.cameras.main.centerX + 100,
+            y: 300,
+            icon: 'heart',
+            size: 'xl',
+            color: 'red',
+            variant: 'outline',
+            onClick: () => {
+                console.log('Outline heart clicked!');
+            },
+        });
+        this.add.existing(outlineHeart);
     }
 }`}</code></pre>
       </div>
@@ -529,8 +545,50 @@ import { type ColorKey, type ColorToken, type FontSizeKey } from 'phaser-wind';
         fontSize: '12px',
       }).setOrigin(0.5, 0.5);
 
+      // Outline variant row
+      this.add.text(this.cameras.main.centerX, 650, 'Outline Variant', {
+        color: pw.color.slate(300),
+        align: 'center',
+        fontFamily: 'Fredoka',
+        fontSize: '18px',
+      }).setOrigin(0.5, 0.5);
+
+      const outlineConfigs: { icon: IconKey, color: ColorKey, label: string, x: number }[] = [
+        { icon: 'heart' as IconKey, color: 'red' as ColorKey, label: 'Heart', x: this.cameras.main.centerX - 240 },
+        { icon: 'star' as IconKey, color: 'yellow' as ColorKey, label: 'Star', x: this.cameras.main.centerX - 120 },
+        { icon: 'play' as IconKey, color: 'green' as ColorKey, label: 'Play', x: this.cameras.main.centerX },
+        { icon: 'gear' as IconKey, color: 'blue' as ColorKey, label: 'Gear', x: this.cameras.main.centerX + 120 },
+        { icon: 'envelope' as IconKey, color: 'cyan' as ColorKey, label: 'Mail', x: this.cameras.main.centerX + 240 },
+      ];
+
+      outlineConfigs.forEach((config) => {
+        const outlineButton = new IconButton({
+          scene: this,
+          x: config.x,
+          y: 710,
+          icon: config.icon,
+          size: 'lg',
+          color: config.color,
+          variant: 'outline',
+          onClick: () => {
+            this.clickCount++;
+            if (this.clickText) {
+              this.clickText.setText(`Clicks: ${this.clickCount}`);
+            }
+          },
+        });
+        this.add.existing(outlineButton);
+        this.buttons.push(outlineButton);
+
+        this.add.text(config.x, 760, config.label, {
+          color: pw.color.slate(400),
+          align: 'center',
+          fontSize: '12px',
+        }).setOrigin(0.5, 0.5);
+      });
+
       // Add instructions
-      this.add.text(this.cameras.main.centerX, 640, 'Hover and click the buttons to see interactions', {
+      this.add.text(this.cameras.main.centerX, 795, 'Hover and click the buttons to see interactions', {
         color: pw.color.slate(400),
         align: 'center',
         fontSize: '14px',

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -154,6 +154,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Horizontal layout container for organizing content</p>
         </a>
 
+        <a href={getUrl('/hudini/stack')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">🧱</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Stack</h4>
+          </div>
+          <p class="text-sm text-gray-600">Row or Column layout with optional background — daisyUI-style flex container</p>
+        </a>
+
         <a href={getUrl('/hudini/sized-box')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">📏</span>

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -162,6 +162,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Row or Column layout with optional background — daisyUI-style flex container</p>
         </a>
 
+        <a href={getUrl('/hudini/dock')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">⚓</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Dock</h4>
+          </div>
+          <p class="text-sm text-gray-600">Bottom-navigation bar with icon+label items and a controlled active state</p>
+        </a>
+
         <a href={getUrl('/hudini/sized-box')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">📏</span>

--- a/packages/showcase/src/pages/hudini/stack.astro
+++ b/packages/showcase/src/pages/hudini/stack.astro
@@ -1,0 +1,317 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Stack Component" description="Row or Column layout with optional background, padding and border radius — the equivalent of a Tailwind flex div in canvas.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Stack Component</h2>
+      <p class="text-gray-600 mb-4">
+        Layout primitive that arranges children in a <code class="bg-gray-100 px-1 rounded">'row'</code> or <code class="bg-gray-100 px-1 rounded">'column'</code>.
+        When <code class="bg-gray-100 px-1 rounded">backgroundColor</code>, <code class="bg-gray-100 px-1 rounded">padding</code> or <code class="bg-gray-100 px-1 rounded">borderRadius</code> is set, Stack also
+        renders a Card behind the children — matching the Tailwind pattern
+        <code class="bg-gray-100 px-1 rounded">&lt;div class="flex flex-row bg-slate-800 p-4 rounded-lg"&gt;...&lt;/div&gt;</code>.
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>🎯 <strong>Direction</strong>: <code>'row'</code> or <code>'column'</code> — one component, two behaviors</li>
+          <li>🎨 <strong>Optional background</strong>: pass <code>backgroundColor</code> to render a Card behind the children</li>
+          <li>📏 <strong>Padding</strong>: inner spacing between children and the background's edge</li>
+          <li>🔲 <strong>Border radius</strong>: rounded corners on the background</li>
+          <li>🧩 <strong>Composes</strong>: measure via <code>.width</code> / <code>.height</code> so a parent Row/Column/Stack lays it out correctly</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">direction</code> - <code>'row'</code> (default) or <code>'column'</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">gap</code> - Space between children in pixels (default: 8)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">align</code> - Cross-axis alignment (<code>'top'|'center'|'bottom'</code> for row, <code>'left'|'center'|'right'</code> for column)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">children</code> - GameObjects to stack</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">padding</code> - Inner padding (SpacingKey or px). Only visible with a background</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">backgroundColor</code> - Optional fill color (ColorKey or CSS)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code> - Border radius on the background (RadiusKey or px)</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={640} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Stack,
+    TextButton,
+    Badge,
+} from 'hudini';
+
+const theme = createTheme({});
+type Theme = typeof theme;
+
+class StackDemoScene extends Phaser.Scene {
+    create(): void {
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
+        this.cameras.main.setBackgroundColor(pw.color.slate(300));
+
+        // 1. Pure layout — no background
+        const row = new Stack({
+            scene: this,
+            x: 400,
+            y: 100,
+            direction: 'row',
+            gap: 12,
+            children: [
+                new TextButton({ scene: this, x: 0, y: 0, text: 'A', color: 'blue-500' }),
+                new TextButton({ scene: this, x: 0, y: 0, text: 'B', color: 'green-500' }),
+                new TextButton({ scene: this, x: 0, y: 0, text: 'C', color: 'red-500' }),
+            ],
+        });
+        this.add.existing(row);
+
+        // 2. Layout + background (like <div class="flex bg-slate-800 p-4 rounded-lg">)
+        const paddedRow = new Stack({
+            scene: this,
+            x: 400,
+            y: 250,
+            direction: 'row',
+            gap: 12,
+            padding: '4',
+            backgroundColor: 'slate-800',
+            borderRadius: 'lg',
+            children: [
+                new Badge({ scene: this, x: 0, y: 0, text: 'PRO', color: 'purple-600' }),
+                new Badge({ scene: this, x: 0, y: 0, text: 'NEW', color: 'green-600' }),
+                new Badge({ scene: this, x: 0, y: 0, text: 'HOT', color: 'red-600' }),
+            ],
+        });
+        this.add.existing(paddedRow);
+
+        // 3. Column direction
+        const column = new Stack({
+            scene: this,
+            x: 400,
+            y: 450,
+            direction: 'column',
+            gap: 8,
+            padding: '4',
+            backgroundColor: 'slate-700',
+            borderRadius: 'md',
+            children: [
+                new TextButton({ scene: this, x: 0, y: 0, text: 'Save' }),
+                new TextButton({ scene: this, x: 0, y: 0, text: 'Cancel', color: 'gray-500' }),
+            ],
+        });
+        this.add.existing(column);
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Stack,
+    TextButton,
+    Badge,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class StackDemoScene extends Phaser.Scene {
+    constructor() {
+      super('stack-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(300));
+
+      const centerX = this.cameras.main.centerX;
+
+      // Header
+      this.add
+        .text(centerX, 40, 'Stack Component', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Section 1: Row, no background ---
+      this.add
+        .text(centerX, 90, "direction: 'row' — pure layout", {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '14px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const rowNoBg = new Stack({
+        scene: this,
+        x: centerX,
+        y: 140,
+        direction: 'row',
+        gap: 12,
+        children: [
+          new TextButton({ scene: this, x: 0, y: 0, text: 'A', color: 'blue-500', padding: '3' }),
+          new TextButton({ scene: this, x: 0, y: 0, text: 'B', color: 'green-500', padding: '3' }),
+          new TextButton({ scene: this, x: 0, y: 0, text: 'C', color: 'red-500', padding: '3' }),
+        ],
+      });
+      this.add.existing(rowNoBg);
+
+      // --- Section 2: Row with background ---
+      this.add
+        .text(centerX, 210, "with backgroundColor + padding + borderRadius", {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '14px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const rowWithBg = new Stack({
+        scene: this,
+        x: centerX,
+        y: 265,
+        direction: 'row',
+        gap: 10,
+        padding: '4',
+        backgroundColor: 'slate-800',
+        borderRadius: 'lg',
+        children: [
+          new Badge({ scene: this, x: 0, y: 0, text: 'PRO', color: 'purple-600' }),
+          new Badge({ scene: this, x: 0, y: 0, text: 'NEW', color: 'green-600' }),
+          new Badge({ scene: this, x: 0, y: 0, text: 'HOT', color: 'red-600' }),
+          new Badge({ scene: this, x: 0, y: 0, text: 'BETA', color: 'amber-600' }),
+        ],
+      });
+      this.add.existing(rowWithBg);
+
+      // --- Section 3: Column direction with bg ---
+      this.add
+        .text(centerX - 180, 340, "direction: 'column' with bg", {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '14px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const columnWithBg = new Stack({
+        scene: this,
+        x: centerX - 180,
+        y: 460,
+        direction: 'column',
+        gap: 10,
+        padding: '4',
+        backgroundColor: 'slate-800',
+        borderRadius: 'md',
+        children: [
+          new TextButton({ scene: this, x: 0, y: 0, text: 'Save', color: 'blue-500', padding: '3' }),
+          new TextButton({ scene: this, x: 0, y: 0, text: 'Cancel', color: 'gray-500', padding: '3' }),
+          new TextButton({ scene: this, x: 0, y: 0, text: 'Delete', color: 'red-500', padding: '3' }),
+        ],
+      });
+      this.add.existing(columnWithBg);
+
+      // --- Section 4: Nested Stack (row of columns) ---
+      this.add
+        .text(centerX + 140, 340, "Nested — row of column Stacks", {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '14px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const makeColumnCard = (title: string, badgeColor: string) =>
+        new Stack({
+          scene: this,
+          x: 0,
+          y: 0,
+          direction: 'column',
+          gap: 8,
+          padding: '4',
+          backgroundColor: 'slate-700',
+          borderRadius: 'md',
+          children: [
+            new Badge({ scene: this, x: 0, y: 0, text: title, color: badgeColor }),
+            new TextButton({ scene: this, x: 0, y: 0, text: 'Open', color: 'blue-500', padding: '3' }),
+          ],
+        });
+
+      const nested = new Stack({
+        scene: this,
+        x: centerX + 140,
+        y: 460,
+        direction: 'row',
+        gap: 12,
+        children: [
+          makeColumnCard('DEV', 'green-600'),
+          makeColumnCard('PROD', 'red-600'),
+        ],
+      });
+      this.add.existing(nested);
+
+      // Footer note
+      this.add
+        .text(centerX, 610, 'Stack composes Row/Column + Card in a single node — layout + visual.', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0.5, 0.5);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      loadFonts().then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [StackDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-stack-demo'] = game;
+      });
+    }
+  });
+</script>

--- a/packages/showcase/src/pages/hudini/text-button.astro
+++ b/packages/showcase/src/pages/hudini/text-button.astro
@@ -36,13 +36,14 @@ import PhaserGame from '../../components/PhaserGame.astro';
             <li><code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code> - Border radius token or pixel value</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">padding</code> - Internal padding using spacing tokens</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">fontSize</code> - Text size using typography tokens</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">variant</code> - <code>'filled'</code> (default) or <code>'outline'</code> — daisyUI-style visual variants</li>
           </ul>
         </div>
       </div>
     </div>
 
     <!-- Live Example -->
-    <PhaserGame width={800} height={600} />
+    <PhaserGame width={800} height={720} />
 
     <!-- Usage Example -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -96,6 +97,19 @@ class ButtonDemoScene extends Phaser.Scene {
             padding: '6',
         });
         this.add.existing(secondaryButton);
+
+        // Create an outline button (daisyUI-style)
+        const outlineButton = new TextButton({
+            scene: this,
+            x: this.cameras.main.centerX,
+            y: this.cameras.main.centerY + 130,
+            text: 'Outline Button',
+            color: 'blue-500',
+            borderRadius: 'md',
+            padding: '4',
+            variant: 'outline',
+        });
+        this.add.existing(outlineButton);
     }
 }`}</code></pre>
       </div>
@@ -130,12 +144,29 @@ class ButtonDemoScene extends Phaser.Scene {
       const { pw } = withHudini(this);
       this.cameras.main.setBackgroundColor(pw.color.slate(900));
 
+      const centerX = this.cameras.main.centerX;
+      const width = this.cameras.main.width;
+      const leftX = width / 4;
+      const rightX = (width * 3) / 4;
+
       // Title
-      this.add.text(this.cameras.main.centerX, 80, 'Text Button Examples', {
+      this.add.text(centerX, 40, 'Text Button Examples', {
         color: pw.color.slate(200),
         align: 'center',
         fontFamily: 'Fredoka',
         fontSize: '32px',
+      }).setOrigin(0.5, 0.5);
+
+      // Column headers
+      this.add.text(leftX, 90, 'Filled', {
+        color: pw.color.slate(300),
+        fontFamily: 'Fredoka',
+        fontSize: '20px',
+      }).setOrigin(0.5, 0.5);
+      this.add.text(rightX, 90, 'Outline', {
+        color: pw.color.slate(300),
+        fontFamily: 'Fredoka',
+        fontSize: '20px',
       }).setOrigin(0.5, 0.5);
 
       // Create different button styles
@@ -149,41 +180,53 @@ class ButtonDemoScene extends Phaser.Scene {
         { text: 'Custom', bg: '#3B82F6', textColor: 'white', borderRadius: 'md' },
       ];
 
-      let x = this.cameras.main.width / 4;
-      let y = 150;
+      const startY = 140;
+      const rowSpacing = 75;
       buttonConfigs.forEach((config, index) => {
-        const button = new TextButton({
+        const y = startY + index * rowSpacing;
+
+        // Filled — left column
+        const filled = new TextButton({
           scene: this,
-          x: x,
-          y: y,
+          x: leftX,
+          y,
           text: config.text,
           color: config.bg,
           textColor: config.textColor,
           borderRadius: config.borderRadius,
           padding: '4',
         });
-
-        y += 80;
-
-        // Add click interaction
-        button.setInteractive();
-        button.on('pointerdown', () => {
-          console.log(`${config.text} button clicked!`);
+        filled.setInteractive();
+        filled.on('pointerdown', () => {
+          console.log(`${config.text} (filled) clicked!`);
         });
+        this.add.existing(filled);
+        this.buttons.push(filled);
 
-        this.add.existing(button);
-        this.buttons.push(button);
-
-        if ((index + 1) % 4 === 0) {
-          y = 150;
-          x += this.cameras.main.width / 2;
-        }
+        // Outline — right column
+        const outline = new TextButton({
+          scene: this,
+          x: rightX,
+          y,
+          text: config.text,
+          color: config.bg,
+          borderRadius: config.borderRadius,
+          padding: '4',
+          variant: 'outline',
+        });
+        outline.setInteractive();
+        outline.on('pointerdown', () => {
+          console.log(`${config.text} (outline) clicked!`);
+        });
+        this.add.existing(outline);
+        this.buttons.push(outline);
       });
 
       // Add instructions
-      this.add.text(this.cameras.main.centerX, 500, 'Click and hover over the buttons to see interactions', {
+      this.add.text(centerX, this.cameras.main.height - 30, 'Click and hover over the buttons to see interactions', {
         color: pw.color.slate(400),
         align: 'center',
+        fontFamily: 'Fredoka',
         fontSize: '16px',
       }).setOrigin(0.5, 0.5);
     }


### PR DESCRIPTION
## Description

Two new layout/nav components (Stack + Dock) and a new visual variant (outline) on the existing buttons — filling out the daisyUI-inspired kit inside Hudini.

- **Stack** is the Row/Column + optional background primitive (like `<div class="flex bg-slate-800 p-4 rounded-lg">`).
- **Dock** is a daisyUI-style bottom-navigation bar (icon + label per item, click callback, controlled active state).
- **Outline variant** on `TextButton` and `IconButton` (transparent bg + colored border + colored glyph).

## Type of Change

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [x] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [x] hudini
- [ ] phaser-sound-studio
- [ ] phaser-data-studio
- [x] showcase
- [ ] virtual-joystick
- [ ] Other (please specify): ______

## Changes

### Added

**hudini**
- `Stack` component (`packages/hudini/src/components/stack/`) — Row or Column layout with optional `backgroundColor`, `padding`, `borderRadius`. Internally instantiates Row/Column based on `direction` + a Card behind them when a background is requested. Exposes `layoutContainer` (the inner Row/Column) and `background` (the Card or `null`) for advanced access. Sizes itself so a parent Row/Column/Stack measures it correctly.
- `Dock` component (`packages/hudini/src/components/dock/`) — daisyUI-style bottom navigation. Accepts `items: DockItem[]` (`{ id, icon, label }`), an optional `active` id and an `onSelect(id, index)` callback. The client controls the visual active state via `dock.setActiveItem(id)`, matching a "controlled component" contract — no built-in tab/routing behavior.
- `ButtonVariant = 'filled' | 'outline'` type + `BUTTON_OUTLINE_THICKNESS` constant in `utils/button-style.ts`.
- `variant` prop on `TextButton` and `IconButton`, plus `setVariant(v)` runtime setter on both.

### Changed

**hudini**
- `TextButton` — outline mode uses no text stroke (border carries the visual weight), text color defaults to the button `color` (daisyUI parity) unless overridden. Filled mode's legacy behavior is preserved: constructor `textColor` param stays inert unless variant is `outline` (only `setTextColor()` mutates the filled text color post-construction) — avoids regressing Secondary/Warning-style buttons.
- `IconButton` — same treatment for outline: colored icon, no icon stroke, colored border inset by half its thickness so the outer edge sits exactly at the visual box boundary (`.width`/`.height` stay accurate for Row/Column/Stack measurement).
- `Card` — fixed a latent bug: when constructed with explicit `width`/`height`, the initial `createBackgroundTexture` call read `this.width`/`this.height` via `ContainerInteractive`'s getter, which returned `0` because `hitArea` isn't wired yet in the constructor. Card now caches the dims in `explicitWidth`/`explicitHeight` and `getCardDimensions` consults them first. After `hitArea` is set, the dims are propagated to the sprite so external `card.width` reads real values. This was blocking Stack from rendering its background.
- Hudini components barrel (`components/index.ts`) exports `stack` and `dock`.

**showcase**
- New pages `pages/hudini/stack.astro` and `pages/hudini/dock.astro` with live demos.
- `text-button.astro` reformed into two columns — Filled | Outline — for a side-by-side comparison across the same color set. Canvas height bumped to 720.
- `icon-button.astro` adds an "Outline Variant" row at the bottom with 5 icons. Canvas height bumped to 820.
- Sidebar (`Layout.astro`) and hudini index card get entries for 🧱 Stack and ⚓ Dock.

## How to Test

1. `pnpm --filter hudini test` — expect **46/46** passing (added specs for Stack + Dock). `card.spec.ts` continues to fail at collection due to a pre-existing `Phaser.Scene` issue in the deprecated `SceneWithPhaserWind`; not caused by this PR.
2. `pnpm --filter hudini tsc --noEmit` — clean.
3. `pnpm --filter phaser-toolkit-showcase build` — should generate **30 pages** without errors.
4. Open the showcase locally and visit:
   - `/hudini/stack` — 4 example sections (Row no-bg, Row with bg, Column with bg, nested).
   - `/hudini/dock` — bottom dock with 4 items updating a live "Current selection" label; a bare dock variant below.
   - `/hudini/text-button` — Filled and Outline columns side-by-side; Secondary/Warning render as they did before (no regression).
   - `/hudini/icon-button` — the new Outline Variant row at the bottom.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)