### PR TITLE
feat(hudini): Stack, Dock, Alert, Checkbox, Toggle, Radio + form primitives

### DIFF
--- a/.changeset/eight-meals-cough.md
+++ b/.changeset/eight-meals-cough.md
@@ -1,0 +1,5 @@
+---
+'hudini': minor
+---
+
+Add checkbox, toggle, radio, radiogroup, icons in text button

--- a/packages/hudini/src/components/alert/alert.spec.ts
+++ b/packages/hudini/src/components/alert/alert.spec.ts
@@ -1,0 +1,246 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable sonarjs/no-identical-functions */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 40;
+    public height = 20;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    layout(): void {
+      /* noop */
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
+vi.mock('phaser-wind', () => ({
+  Color: {
+    rgb: vi.fn((color: string) => `rgb-${color}`),
+    hex: vi.fn((color: string) => `hex-${color}`),
+    /* eslint-disable-next-line no-unused-vars */
+    shift: vi.fn((token: string, _diff: number) => token),
+    isValidColorToken: vi.fn(() => false),
+  },
+  Opacity: {
+    value: vi.fn(() => 0.6),
+  },
+  isColorKey: vi.fn(() => false),
+  palette: {
+    red: {}, blue: {}, green: {}, yellow: {}, slate: {}, black: '#000', white: '#fff',
+  },
+}));
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    fontSize: {
+      px: vi.fn((size: string) => {
+        const sizes = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+        return sizes[size as keyof typeof sizes] || 16;
+      }),
+    },
+    spacing: {
+      px: vi.fn(() => 16),
+    },
+    radius: {
+      px: vi.fn(() => 8),
+    },
+    font: {
+      family: vi.fn(() => 'Fredoka'),
+    },
+  })),
+}));
+
+vi.mock('../text', () => {
+  class MockText {
+    private text: string;
+    // eslint-disable-next-line no-unused-vars
+    constructor(params: { text: string }) {
+      this.text = params.text;
+    }
+    setText(t: string): this {
+      this.text = t;
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    getBounds(): { width: number; height: number } {
+      return { width: this.text.length * 10, height: 18 };
+    }
+  }
+  return { Text: MockText };
+});
+
+vi.mock('phaser', () => {
+  class MockSprite {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _texture: string) {}
+    setOrigin(): this {
+      return this;
+    }
+    setInteractive(): this {
+      return this;
+    }
+    setTexture(): this {
+      return this;
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+    on(): this {
+      return this;
+    }
+  }
+  class MockGraphics {
+    fillStyle(): this {
+      return this;
+    }
+    fillRoundedRect(): this {
+      return this;
+    }
+    generateTexture(): this {
+      return this;
+    }
+    destroy(): this {
+      return this;
+    }
+  }
+  class Container {
+    scene: Scene;
+    list: unknown[] = [];
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    remove(): this {
+      return this;
+    }
+    addAt(): this {
+      return this;
+    }
+  }
+  class Scene {
+    add = {
+      existing: vi.fn(),
+      sprite: vi.fn((x: number, y: number, t: string) => new MockSprite(x, y, t)),
+      graphics: vi.fn(() => new MockGraphics()),
+    };
+  }
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Alert } from './alert';
+
+describe('Alert', () => {
+  it('should create with the info variant by default', () => {
+    const scene = new Scene();
+    const alert = new Alert({ scene, x: 0, y: 0, text: 'hello' });
+    expect(alert).toBeInstanceOf(Alert);
+  });
+
+  it('should accept every semantic variant', () => {
+    const scene = new Scene();
+    const variants = ['success', 'error', 'warning', 'info', 'neutral'] as const;
+    variants.forEach((variant) => {
+      const alert = new Alert({ scene, x: 0, y: 0, text: 't', variant });
+      expect(alert).toBeInstanceOf(Alert);
+    });
+  });
+
+  it('should honor a custom color override', () => {
+    const scene = new Scene();
+    const alert = new Alert({
+      scene,
+      x: 0,
+      y: 0,
+      text: 't',
+      variant: 'success',
+      color: 'purple-600',
+    });
+    expect(alert).toBeInstanceOf(Alert);
+  });
+
+  it('should disable the default icon when leftIcon is explicitly null', () => {
+    const scene = new Scene();
+    const alert = new Alert({
+      scene,
+      x: 0,
+      y: 0,
+      text: 't',
+      variant: 'success',
+      leftIcon: null,
+    });
+    expect(alert.leftIconText).toBeUndefined();
+  });
+
+  it('should use the variant default leftIcon when leftIcon is omitted', () => {
+    const scene = new Scene();
+    const alert = new Alert({
+      scene,
+      x: 0,
+      y: 0,
+      text: 't',
+      variant: 'success',
+    });
+    expect(alert.leftIconText).toBeDefined();
+  });
+
+  it('should return this for chaining on setters', () => {
+    const scene = new Scene();
+    const alert = new Alert({ scene, x: 0, y: 0, text: 't' });
+    expect(alert.setText('new')).toBe(alert);
+    expect(alert.setColor('red-500')).toBe(alert);
+    expect(alert.setVariant('warning')).toBe(alert);
+  });
+
+  it('should support an optional onClick', () => {
+    const scene = new Scene();
+    const alert = new Alert({
+      scene,
+      x: 0,
+      y: 0,
+      text: 't',
+      onClick: (): void => {
+        /* noop */
+      },
+    });
+    expect(alert).toBeInstanceOf(Alert);
+  });
+});

--- a/packages/hudini/src/components/alert/alert.ts
+++ b/packages/hudini/src/components/alert/alert.ts
@@ -1,0 +1,462 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
+/* eslint-disable max-lines */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
+import { GameObjects, Scene } from 'phaser';
+import {
+  Color,
+  PhaserWindPlugin,
+  type ColorKey,
+  type FontKey,
+  type FontSizeKey,
+  type RadiusKey,
+  type SpacingKey,
+} from 'phaser-wind';
+
+import {
+  BUTTON_STROKE_THICKNESS,
+  getButtonStrokeColor,
+} from '../../utils/button-style';
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { ContainerInteractive } from '../container-interactive';
+import { Stack } from '../stack';
+import { Text } from '../text';
+
+/**
+ * Semantic color intent for an Alert. Each variant defines a default fill
+ * color and (for the semantic ones) a default left icon — matching daisyUI's
+ * alert conventions.
+ */
+export type AlertVariant =
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'neutral';
+
+/** Parameters for creating an {@link Alert}. */
+export type AlertParams = {
+  /** Phaser scene where the alert will be added. */
+  scene: Scene;
+  /** X position (center of the alert box). */
+  x: number;
+  /** Y position (center of the alert box). */
+  y: number;
+  /** Alert text. */
+  text: string;
+  /**
+   * Semantic variant. Drives the default `color` and default `leftIcon`.
+   * Defaults to `'info'`.
+   */
+  variant?: AlertVariant;
+  /**
+   * Background color. Overrides the variant's default. Accepts a palette
+   * family (`'blue'`), a full token (`'blue-500'`), a theme key, or a CSS
+   * string.
+   */
+  color?: ColorKey | string;
+  /** Text color. Defaults to `'white'`. */
+  textColor?: ColorKey | string;
+  /**
+   * Font Awesome icon shown to the LEFT of the text. When omitted, uses the
+   * variant's default (`circle-check` for success, `circle-xmark` for error,
+   * etc). Pass `null` to explicitly disable the default icon.
+   */
+  leftIcon?: IconKey | null;
+  /**
+   * Font Awesome icon shown to the RIGHT of the text. No default — omit for
+   * no right icon, or pass an icon key (commonly `'xmark'` for a "close"
+   * affordance).
+   */
+  rightIcon?: IconKey;
+  /**
+   * Font size in px (number) or a Phaser Wind font size token. Defaults to
+   * `'base'`.
+   */
+  fontSize?: FontSizeKey | number;
+  /** Font family. Defaults to `'Fredoka'`. */
+  font?: FontKey | string;
+  /**
+   * Border radius in px (number) or a Phaser Wind radius token. Defaults to
+   * `'md'`.
+   */
+  borderRadius?: RadiusKey | number;
+  /**
+   * Inner padding around the content in px (number) or a Phaser Wind spacing
+   * token. Defaults to `'4'`.
+   */
+  padding?: SpacingKey | number;
+  /**
+   * Gap between icons and text in pixels. Defaults to a value proportional
+   * to the font size.
+   */
+  iconGap?: number;
+  /**
+   * Optional click handler. When provided, the alert becomes interactive
+   * and the cursor turns into a pointer on hover. When omitted, the alert
+   * is a static banner.
+   */
+  onClick?: () => void;
+};
+
+type VariantConfig = {
+  color: ColorKey;
+  leftIcon: IconKey | undefined;
+};
+
+const VARIANT_CONFIGS: Record<AlertVariant, VariantConfig> = {
+  success: { color: 'green-500' as ColorKey, leftIcon: 'circle-check' },
+  error: { color: 'red-500' as ColorKey, leftIcon: 'circle-xmark' },
+  warning: { color: 'yellow-500' as ColorKey, leftIcon: 'triangle-exclamation' },
+  info: { color: 'blue-500' as ColorKey, leftIcon: 'circle-info' },
+  neutral: { color: 'slate-600' as ColorKey, leftIcon: undefined },
+};
+
+/** See {@link TEXTURE_ANTIALIAS_MARGIN} in text-button. */
+const TEXTURE_ANTIALIAS_MARGIN = 1;
+const MIN_ICON_TEXT_GAP_PX = 4;
+const ICON_TEXT_GAP_RATIO = 0.35;
+
+/**
+ * Alert — a static (or optionally clickable) notification banner.
+ *
+ * Same visual language as a filled `TextButton` (colored fill + white
+ * outlined text + optional icons), but without hover/click tweens.
+ * Semantic variants (`success`/`error`/`warning`/`info`/`neutral`) come with
+ * sensible default colors and icons.
+ *
+ * Meant to be used inline (permanent banner, form error, achievement popup)
+ * or wrapped in a Toast for auto-dismiss behavior (separate component).
+ *
+ * @example
+ * new Alert({
+ *   scene, x: 400, y: 100,
+ *   variant: 'success',
+ *   text: 'Player saved!',
+ * });
+ *
+ * @example
+ * // With a right icon acting as a "close" hint + a click handler
+ * new Alert({
+ *   scene, x: 400, y: 100,
+ *   variant: 'warning',
+ *   text: 'Low health!',
+ *   rightIcon: 'xmark',
+ *   onClick: () => alert.destroy(),
+ * });
+ */
+export class Alert extends ContainerInteractive<Phaser.GameObjects.Sprite> {
+  /** The background sprite of the alert. */
+  public backgroundSprite!: GameObjects.Sprite;
+  /** The text object. */
+  public alertText!: GameObjects.Text;
+  /** The horizontal Stack composing [leftIcon?, text, rightIcon?]. */
+  public contentStack!: Stack;
+  /** Left icon glyph, when set (either by variant default or explicit). */
+  public leftIconText: IconText | undefined;
+  /** Right icon glyph, when explicitly set. */
+  public rightIconText: IconText | undefined;
+
+  private pw: PhaserWindPlugin<{}>;
+  private fontSizePx!: number;
+  private paddingPx!: number;
+  private borderRadiusPx!: number;
+  private colorInput!: string;
+  private colorAlert!: string;
+  private textColorValue!: string;
+  private fontFamily!: string;
+  private textValue!: string;
+  private variant!: AlertVariant;
+  private leftIconKey: IconKey | undefined;
+  private rightIconKey: IconKey | undefined;
+  private iconGap: number | undefined;
+
+  constructor({
+    scene,
+    x,
+    y,
+    text,
+    variant = 'info',
+    color,
+    textColor = 'white',
+    leftIcon,
+    rightIcon,
+    fontSize = 'base',
+    font,
+    borderRadius = 'md',
+    padding = '4',
+    iconGap,
+    onClick,
+  }: AlertParams) {
+    super({ scene, x, y });
+    this.pw = getPWFromScene(scene);
+
+    // Resolve variant defaults.
+    const variantConfig = VARIANT_CONFIGS[variant];
+    const resolvedColor = color ?? variantConfig.color;
+    // `leftIcon === null` means "explicitly disable the default"; omitting
+    // it falls back to the variant's default; passing an IconKey overrides.
+    const resolvedLeftIcon =
+      leftIcon === null
+        ? undefined
+        : leftIcon ?? variantConfig.leftIcon;
+
+    this.variant = variant;
+    this.textValue = text;
+    this.leftIconKey = resolvedLeftIcon;
+    this.rightIconKey = rightIcon;
+    this.iconGap = iconGap;
+
+    this.fontSizePx =
+      typeof fontSize === 'number'
+        ? fontSize
+        : this.pw.fontSize.px(fontSize ?? ('base' as FontSizeKey));
+
+    this.paddingPx =
+      typeof padding === 'number'
+        ? padding
+        : this.pw.spacing.px(padding ?? ('4' as SpacingKey));
+
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
+
+    this.colorInput = String(resolvedColor);
+    this.colorAlert = Color.rgb(resolvedColor as ColorKey);
+
+    this.textColorValue = Color.rgb(textColor as ColorKey);
+    this.fontFamily = font
+      ? typeof font === 'string'
+        ? font
+        : this.pw.font.family(font)
+      : 'Fredoka';
+
+    this.createAlertContent(scene);
+    this.createBackgroundSprite(scene);
+    this.setupContainer();
+    this.hitArea = this.backgroundSprite;
+    if (onClick) {
+      this.setupClickHandler(onClick);
+    }
+    this.syncContainerSize();
+  }
+
+  /** Change the alert text. */
+  public setText(text: string): this {
+    this.textValue = text;
+    this.alertText.setText(text);
+    this.contentStack.layout();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Change the background color (overrides the variant's default). */
+  public setColor(color: ColorKey | string): this {
+    this.colorInput = String(color);
+    this.colorAlert = Color.rgb(color as ColorKey);
+    // Text stroke derives from colorInput — rebuild content.
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Change the text color. */
+  public setTextColor(color: ColorKey | string): this {
+    this.textColorValue = Color.rgb(color as ColorKey);
+    this.alertText.setColor(this.textColorValue);
+    this.leftIconText?.setColor(this.textColorValue);
+    this.rightIconText?.setColor(this.textColorValue);
+    return this;
+  }
+
+  /**
+   * Switch to another semantic variant. Applies the variant's default color
+   * and left icon unless the caller had previously overridden them (in which
+   * case the overrides stick — call `setColor` / `setLeftIcon` separately to
+   * clear them).
+   */
+  public setVariant(variant: AlertVariant): this {
+    if (this.variant === variant) return this;
+    this.variant = variant;
+    const cfg = VARIANT_CONFIGS[variant];
+    this.colorInput = String(cfg.color);
+    this.colorAlert = Color.rgb(cfg.color);
+    this.leftIconKey = cfg.leftIcon;
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Set (or clear with `undefined`) the left icon. */
+  public setLeftIcon(icon: IconKey | undefined): this {
+    this.leftIconKey = icon;
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Set (or clear with `undefined`) the right icon. */
+  public setRightIcon(icon: IconKey | undefined): this {
+    this.rightIconKey = icon;
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Change the border radius. */
+  public setBorderRadius(borderRadius: RadiusKey | number): this {
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('md' as RadiusKey));
+    this.regenerateSprites();
+    return this;
+  }
+
+  /** Change the inner padding. */
+  public setPadding(padding: SpacingKey | number): this {
+    this.paddingPx =
+      typeof padding === 'number'
+        ? padding
+        : this.pw.spacing.px(padding ?? ('4' as SpacingKey));
+    this.regenerateSprites();
+    return this;
+  }
+
+  private createAlertContent(scene: Scene): void {
+    const strokeThickness = BUTTON_STROKE_THICKNESS;
+    const strokeColor = getButtonStrokeColor(this.colorInput);
+
+    this.alertText = new Text({
+      scene,
+      x: 0,
+      y: 0,
+      text: this.textValue,
+      size: this.fontSizePx,
+      fontFamily: this.fontFamily,
+      strokeThickness,
+      strokeColor,
+    });
+    this.alertText.setColor(this.textColorValue);
+    this.alertText.setOrigin(0.5, 0.5);
+
+    this.leftIconText = this.leftIconKey
+      ? this.createIcon(scene, this.leftIconKey, strokeColor, strokeThickness)
+      : undefined;
+    this.rightIconText = this.rightIconKey
+      ? this.createIcon(scene, this.rightIconKey, strokeColor, strokeThickness)
+      : undefined;
+
+    const children: GameObjects.GameObject[] = [];
+    if (this.leftIconText) children.push(this.leftIconText);
+    children.push(this.alertText);
+    if (this.rightIconText) children.push(this.rightIconText);
+
+    const gap =
+      this.iconGap ??
+      Math.max(
+        MIN_ICON_TEXT_GAP_PX,
+        Math.round(this.fontSizePx * ICON_TEXT_GAP_RATIO)
+      );
+    this.contentStack = new Stack({
+      scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap,
+      children,
+    });
+  }
+
+  private createIcon(
+    scene: Scene,
+    icon: IconKey,
+    strokeColor: string,
+    strokeThickness: number
+  ): IconText {
+    const iconText = new IconText({
+      scene,
+      x: 0,
+      y: 0,
+      icon,
+      size: this.fontSizePx,
+      style: {
+        color: this.textColorValue,
+        strokeThickness,
+        stroke: strokeColor,
+      },
+    });
+    iconText.setFontStyle('900');
+    iconText.setOrigin(0.5, 0.5);
+    scene.add.existing(iconText);
+    return iconText;
+  }
+
+  private rebuildContent(): void {
+    this.remove(this.contentStack, true);
+    this.createAlertContent(this.scene);
+    this.add(this.contentStack);
+  }
+
+  private createBackgroundSprite(scene: Scene): void {
+    const backgroundTexture = this.createBackgroundTexture(scene);
+    this.backgroundSprite = scene.add.sprite(0, 0, backgroundTexture);
+    this.backgroundSprite.setOrigin(0.5, 0.5);
+  }
+
+  private regenerateSprites(): void {
+    this.alertText.setText(this.textValue);
+    this.contentStack.layout();
+    const backgroundTexture = this.createBackgroundTexture(this.scene);
+    this.backgroundSprite.setTexture(backgroundTexture);
+    this.syncContainerSize();
+  }
+
+  private syncContainerSize(): void {
+    const { width, height } = this.getAlertDimensions();
+    this.setSize(width, height);
+  }
+
+  private getAlertDimensions(): { width: number; height: number } {
+    const contentWidth = this.contentStack.width;
+    const contentHeight = this.contentStack.height;
+    return {
+      width: contentWidth + this.paddingPx * 2,
+      height: contentHeight + this.paddingPx * 2,
+    };
+  }
+
+  private createBackgroundTexture(scene: Scene): string {
+    const { width, height } = this.getAlertDimensions();
+    const textureKey = `alert_bg_${this.colorAlert}_${this.borderRadiusPx}_${width}_${height}`;
+
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
+    const textureWidth = width + padding * 2;
+    const textureHeight = height + padding * 2;
+
+    const graphics = scene.add.graphics();
+
+    const maxRadius = Math.floor(Math.min(width / 2, height / 2));
+    const effectiveRadius = Math.min(this.borderRadiusPx, maxRadius);
+    const finalRadius = Math.max(0, effectiveRadius);
+
+    graphics.fillStyle(Color.hex(this.colorAlert), 1);
+    graphics.fillRoundedRect(padding, padding, width, height, finalRadius);
+
+    graphics.generateTexture(textureKey, textureWidth, textureHeight);
+    graphics.destroy();
+
+    return textureKey;
+  }
+
+  private setupContainer(): void {
+    this.add([this.backgroundSprite, this.contentStack]);
+  }
+
+  private setupClickHandler(onClick: () => void): void {
+    this.backgroundSprite.setInteractive({ useHandCursor: true });
+    this.backgroundSprite.on('pointerdown', onClick);
+  }
+}

--- a/packages/hudini/src/components/alert/index.ts
+++ b/packages/hudini/src/components/alert/index.ts
@@ -1,0 +1,1 @@
+export * from './alert';

--- a/packages/hudini/src/components/checkbox/checkbox.spec.ts
+++ b/packages/hudini/src/components/checkbox/checkbox.spec.ts
@@ -1,0 +1,381 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable max-lines */
+/* eslint-disable sonarjs/no-identical-functions */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+    setScale(): this {
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 40;
+    public height = 20;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    layout(): void {
+      /* noop */
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
+vi.mock('phaser-wind', () => ({
+  Color: {
+    rgb: vi.fn((color: string) => `rgb-${color}`),
+    hex: vi.fn(() => 0x3b82f6),
+  },
+  Opacity: {
+    value: vi.fn(() => 0.1),
+  },
+}));
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    fontSize: {
+      px: vi.fn((size: string) => {
+        const sizes = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+        return sizes[size as keyof typeof sizes] || 16;
+      }),
+    },
+    radius: {
+      px: vi.fn(() => 4),
+    },
+  })),
+}));
+
+vi.mock('../text', () => {
+  class MockText {
+    private text: string;
+    public width = 60;
+    // eslint-disable-next-line no-unused-vars
+    constructor(params: { text: string }) {
+      this.text = params.text;
+    }
+    setText(t: string): this {
+      this.text = t;
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+    getBounds(): { width: number; height: number } {
+      return { width: this.text.length * 10, height: 18 };
+    }
+  }
+  return { Text: MockText };
+});
+
+vi.mock('phaser', () => {
+  class MockSprite {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _texture: string) {}
+    setOrigin(): this {
+      return this;
+    }
+    setTexture(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+  }
+  class MockRectangle {
+    public width = 0;
+    public height = 0;
+    public listeners: Record<string, Array<() => void>> = {};
+    constructor(
+      _x: number,
+      _y: number,
+      w: number,
+      h: number,
+      // eslint-disable-next-line no-unused-vars
+      _c: number,
+      // eslint-disable-next-line no-unused-vars
+      _a: number
+    ) {
+      this.width = w;
+      this.height = h;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setInteractive(): this {
+      return this;
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+    on(evt: string, cb: () => void): this {
+      (this.listeners[evt] ||= []).push(cb);
+      return this;
+    }
+    emit(evt: string): this {
+      (this.listeners[evt] ?? []).forEach((cb) => cb());
+      return this;
+    }
+  }
+  class MockGraphics {
+    fillStyle(): this {
+      return this;
+    }
+    fillRoundedRect(): this {
+      return this;
+    }
+    lineStyle(): this {
+      return this;
+    }
+    strokeRoundedRect(): this {
+      return this;
+    }
+    generateTexture(): this {
+      return this;
+    }
+    destroy(): this {
+      return this;
+    }
+  }
+  class MockInnerContainer {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _children: unknown[]) {}
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  class Container {
+    scene: Scene;
+    list: unknown[] = [];
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    remove(): this {
+      return this;
+    }
+    addAt(): this {
+      return this;
+    }
+    setSize(): this {
+      return this;
+    }
+  }
+  class Scene {
+    tweens = {
+      add: vi.fn(),
+      killTweensOf: vi.fn(),
+    };
+    textures = {
+      exists: vi.fn(() => false),
+    };
+    add = {
+      existing: vi.fn(),
+      sprite: vi.fn(
+        (x: number, y: number, texture: string) => new MockSprite(x, y, texture)
+      ),
+      rectangle: vi.fn(
+        (
+          x: number,
+          y: number,
+          w: number,
+          h: number,
+          c: number,
+          a: number
+        ) => new MockRectangle(x, y, w, h, c, a)
+      ),
+      graphics: vi.fn(() => new MockGraphics()),
+      container: vi.fn(
+        (x: number, y: number, children: unknown[]) =>
+          new MockInnerContainer(x, y, children)
+      ),
+    };
+  }
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Checkbox } from './checkbox';
+
+describe('Checkbox', () => {
+  it('should default to unchecked', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0 });
+    expect(cb.getValue()).toBe(false);
+    expect(cb.isChecked()).toBe(false);
+  });
+
+  it('should honor the initial checked prop', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0, checked: true });
+    expect(cb.getValue()).toBe(true);
+  });
+
+  it('should toggle', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0 });
+    cb.toggle();
+    expect(cb.isChecked()).toBe(true);
+    cb.toggle();
+    expect(cb.isChecked()).toBe(false);
+  });
+
+  it('should fire onChange with the new value and name', () => {
+    const scene = new Scene();
+    const changes: Array<[boolean, string | undefined]> = [];
+    const cb = new Checkbox({
+      scene,
+      x: 0,
+      y: 0,
+      name: 'agree',
+      onChange: (v, n): void => {
+        changes.push([v, n]);
+      },
+    });
+    cb.toggle();
+    cb.toggle();
+    expect(changes).toEqual([
+      [true, 'agree'],
+      [false, 'agree'],
+    ]);
+  });
+
+  it('should NOT fire onChange when setChecked is called with the same value', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const cb = new Checkbox({
+      scene,
+      x: 0,
+      y: 0,
+      checked: true,
+      onChange: (): void => { calls++; },
+    });
+    cb.setChecked(true);
+    expect(calls).toBe(0);
+    cb.setChecked(false);
+    expect(calls).toBe(1);
+  });
+
+  it('should ignore toggles when disabled', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const cb = new Checkbox({
+      scene,
+      x: 0,
+      y: 0,
+      disabled: true,
+      onChange: (): void => { calls++; },
+    });
+    // Simulate a click via the hit rect.
+    (cb.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(calls).toBe(0);
+    expect(cb.getValue()).toBe(false);
+  });
+
+  it('should ignore toggles when readOnly, but still fire onChange for programmatic setChecked', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const cb = new Checkbox({
+      scene,
+      x: 0,
+      y: 0,
+      readOnly: true,
+      onChange: (): void => { calls++; },
+    });
+    (cb.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(calls).toBe(0);
+    // Programmatic mutation still works.
+    cb.setChecked(true);
+    expect(calls).toBe(1);
+    expect(cb.getValue()).toBe(true);
+  });
+
+  it('should support disable/enable shortcuts', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0 });
+    expect(cb.isDisabled()).toBe(false);
+    cb.disable();
+    expect(cb.isDisabled()).toBe(true);
+    cb.enable();
+    expect(cb.isDisabled()).toBe(false);
+  });
+
+  it('should support setReadOnly / isReadOnly', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0 });
+    cb.setReadOnly(true);
+    expect(cb.isReadOnly()).toBe(true);
+  });
+
+  it('should allow replacing the onChange callback', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const cb = new Checkbox({ scene, x: 0, y: 0 });
+    cb.onChange((): void => { calls++; });
+    cb.toggle();
+    expect(calls).toBe(1);
+    cb.onChange(undefined);
+    cb.toggle();
+    expect(calls).toBe(1);
+  });
+
+  it('should fire onClick on interaction even when the state does not change', () => {
+    const scene = new Scene();
+    let clicks = 0;
+    const cb = new Checkbox({
+      scene,
+      x: 0,
+      y: 0,
+      onClick: (): void => { clicks++; },
+    });
+    (cb.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(clicks).toBe(1);
+  });
+
+  it('should expose the name prop back through onChange', () => {
+    const scene = new Scene();
+    const cb = new Checkbox({ scene, x: 0, y: 0, name: 'sound' });
+    expect(cb.name).toBe('sound');
+  });
+});

--- a/packages/hudini/src/components/checkbox/checkbox.ts
+++ b/packages/hudini/src/components/checkbox/checkbox.ts
@@ -1,0 +1,472 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
+/* eslint-disable max-lines */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
+import { GameObjects, Scene } from 'phaser';
+import {
+  Color,
+  Opacity,
+  PhaserWindPlugin,
+  type ColorKey,
+  type FontSizeKey,
+  type RadiusKey,
+} from 'phaser-wind';
+
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { ContainerInteractive } from '../container-interactive';
+import { Stack } from '../stack';
+import { Text } from '../text';
+
+/** Parameters for creating a {@link Checkbox}. */
+export type CheckboxParams = {
+  /** Phaser scene where the checkbox will be added. */
+  scene: Scene;
+  /** X position (center of the whole content — box + label). */
+  x: number;
+  /** Y position (center of the whole content). */
+  y: number;
+  /** Initial checked state. Default `false`. */
+  checked?: boolean;
+  /** If `true`, the checkbox is muted and non-interactive. Default `false`. */
+  disabled?: boolean;
+  /** If `true`, the checkbox is visually normal but ignores clicks. Default `false`. */
+  readOnly?: boolean;
+  /**
+   * Optional metadata used by a future Form container. Not consumed by the
+   * Checkbox itself; passed back as the second arg of `onChange`.
+   */
+  name?: string;
+  /**
+   * Optional text label to the right of the box. Clicking the label toggles
+   * the checkbox (same as clicking the box), matching `<label>` behavior.
+   */
+  label?: string;
+  /**
+   * Font Awesome icon key shown when checked. Default `'check'`. Use any FA
+   * key — `'heart'`, `'star'`, `'thumbs-up'` — to theme it per game.
+   */
+  icon?: IconKey;
+  /** Icon color. Default `'white'`. */
+  iconColor?: ColorKey | string;
+  /** Box fill / border color. Default `'blue-500'`. */
+  color?: ColorKey | string;
+  /** Label text color. Default `'slate-800'`. */
+  labelColor?: ColorKey | string;
+  /**
+   * Visual size (font size for the label and reference size for the box).
+   * Default `'base'` (16px). Box side = `size + 8`.
+   */
+  size?: FontSizeKey | number;
+  /** Border radius of the box. Default `'sm'`. */
+  borderRadius?: RadiusKey | number;
+  /** Gap between box and label, in pixels. Default 8. */
+  labelGap?: number;
+  /** Fires whenever the checked state changes (via click or `setChecked`). */
+  onChange?: (checked: boolean, name?: string) => void;
+  /** Fires on any click / tap — regardless of whether the state changed. */
+  onClick?: () => void;
+};
+
+const DEFAULT_SIZE_KEY: FontSizeKey = 'base';
+const DEFAULT_ICON: IconKey = 'check';
+const BOX_PADDING_PX = 4;
+const BOX_BORDER_THICKNESS = 2;
+const TEXTURE_ANTIALIAS_MARGIN = 1;
+const DEFAULT_LABEL_GAP = 8;
+const DISABLED_ALPHA = 0.4;
+const CHECK_TWEEN_DURATION_MS = 140;
+const CHECK_TWEEN_EASE = 'Back.easeOut';
+const UNCHECK_TWEEN_DURATION_MS = 100;
+const UNCHECK_TWEEN_EASE = 'Sine.easeIn';
+
+/**
+ * Checkbox — a toggleable form control.
+ *
+ * The Checkbox owns its own state (uncontrolled). Read it back via
+ * `getValue()` / `isChecked()`, mutate it via `toggle()` / `setChecked(v)`,
+ * observe it via the `onChange` callback.
+ *
+ * For persistent named state, wire it up with `phaser-hooks` on the outside:
+ * `withLocalState(scene, 'settings.sound', true)` + pass `.get()` to
+ * `checked` + call `.set(v)` from `onChange`. The Checkbox stays decoupled.
+ *
+ * @example
+ * const cb = new Checkbox({
+ *   scene, x: 100, y: 100,
+ *   checked: true,
+ *   label: 'Enable sound',
+ *   onChange: (v) => console.log('sound:', v),
+ * });
+ * cb.toggle();
+ * cb.getValue(); // false
+ *
+ * @example
+ * // Custom icon + color (great for game-flavored toggles)
+ * new Checkbox({
+ *   scene, x, y,
+ *   label: 'Favorite',
+ *   icon: 'heart',
+ *   color: 'red-500',
+ * });
+ */
+export class Checkbox extends ContainerInteractive<Phaser.GameObjects.Rectangle> {
+  /** The rectangle drawn as the checkbox box (visible fill + border). */
+  public boxSprite!: GameObjects.Sprite;
+  /** The check-mark icon shown when checked (alpha 0 when unchecked). */
+  public iconText!: IconText;
+  /** Optional label text next to the box, when `label` is set. */
+  public labelText: GameObjects.Text | undefined;
+  /**
+   * The invisible click target sized to `box + label`. Wider than the box
+   * alone so clicking the label also toggles.
+   */
+  public hitRect!: GameObjects.Rectangle;
+
+  private pw: PhaserWindPlugin<{}>;
+  private checkedState: boolean;
+  private disabledState: boolean;
+  private readOnlyState: boolean;
+  private sizePx!: number;
+  private boxSidePx!: number;
+  private borderRadiusPx!: number;
+  private colorInput!: string;
+  private colorFilled!: number;
+  private iconColorValue!: string;
+  private labelColorValue!: string;
+  private iconKey!: IconKey;
+  private labelValue: string | undefined;
+  private labelGap: number;
+  private onChangeCb: ((checked: boolean, name?: string) => void) | undefined;
+  private onClickCb: (() => void) | undefined;
+
+  constructor({
+    scene,
+    x,
+    y,
+    checked = false,
+    disabled = false,
+    readOnly = false,
+    name,
+    label,
+    icon = DEFAULT_ICON,
+    iconColor = 'white',
+    color = 'blue-500',
+    labelColor = 'slate-800',
+    size = DEFAULT_SIZE_KEY,
+    borderRadius = 'sm',
+    labelGap = DEFAULT_LABEL_GAP,
+    onChange,
+    onClick,
+  }: CheckboxParams) {
+    super({ scene, x, y });
+    this.pw = getPWFromScene(scene);
+
+    this.checkedState = checked;
+    this.disabledState = disabled;
+    this.readOnlyState = readOnly;
+    // Store the form field name via Phaser Container's built-in `name` slot.
+    if (name !== undefined) this.name = name;
+    this.labelValue = label;
+    this.iconKey = icon;
+    this.labelGap = labelGap;
+    this.onChangeCb = onChange;
+    this.onClickCb = onClick;
+
+    this.sizePx =
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? DEFAULT_SIZE_KEY);
+    this.boxSidePx = this.sizePx + BOX_PADDING_PX * 2;
+
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('sm' as RadiusKey));
+
+    this.colorInput = String(color);
+    this.colorFilled = Color.hex(color as ColorKey);
+    this.iconColorValue = Color.rgb(iconColor as ColorKey);
+    this.labelColorValue = Color.rgb(labelColor as ColorKey);
+
+    this.createBox(scene);
+    this.createIcon(scene);
+    this.createLabel(scene);
+    this.createHitRect(scene);
+    this.setupContainer();
+    this.hitArea = this.hitRect;
+
+    this.applyDisabledVisual();
+    this.setupInteractivity();
+    this.syncSize();
+  }
+
+  // -------- public API --------
+
+  /** Flip the checked state. Fires `onChange`. */
+  public toggle(): this {
+    return this.setChecked(!this.checkedState);
+  }
+
+  /** Programmatically set the checked state. Fires `onChange` if it changes. */
+  public setChecked(checked: boolean): this {
+    if (this.checkedState === checked) return this;
+    this.checkedState = checked;
+    this.regenerateBoxTexture();
+    this.animateIcon(checked);
+    // Phaser Container `name` defaults to `''`; normalize to `undefined` for
+    // consumers so an unnamed checkbox reads as no-name.
+    this.onChangeCb?.(checked, this.name === '' ? undefined : this.name);
+    return this;
+  }
+
+  /** Current checked state. */
+  public isChecked(): boolean {
+    return this.checkedState;
+  }
+
+  /** Alias for {@link isChecked}, meant for form-style value collection. */
+  public getValue(): boolean {
+    return this.checkedState;
+  }
+
+  /** Set the disabled state (muted + non-interactive). */
+  public setDisabled(disabled: boolean): this {
+    if (this.disabledState === disabled) return this;
+    this.disabledState = disabled;
+    this.applyDisabledVisual();
+    return this;
+  }
+
+  /** Shortcut: `setDisabled(true)`. */
+  public disable(): this {
+    return this.setDisabled(true);
+  }
+
+  /** Shortcut: `setDisabled(false)`. */
+  public enable(): this {
+    return this.setDisabled(false);
+  }
+
+  /** Current disabled state. */
+  public isDisabled(): boolean {
+    return this.disabledState;
+  }
+
+  /**
+   * Set the read-only state. Visually the same as an interactive checkbox,
+   * but clicks are ignored.
+   */
+  public setReadOnly(readOnly: boolean): this {
+    this.readOnlyState = readOnly;
+    return this;
+  }
+
+  /** Current read-only state. */
+  public isReadOnly(): boolean {
+    return this.readOnlyState;
+  }
+
+  /** Replace the change callback. Pass `undefined` to clear. */
+  public onChange(
+    cb: ((checked: boolean, name?: string) => void) | undefined
+  ): this {
+    this.onChangeCb = cb;
+    return this;
+  }
+
+  /** Replace the click callback. Pass `undefined` to clear. */
+  public onClick(cb: (() => void) | undefined): this {
+    this.onClickCb = cb;
+    return this;
+  }
+
+  // -------- private --------
+
+  private createBox(scene: Scene): void {
+    const textureKey = this.getBoxTextureKey();
+    this.drawBoxTexture(scene, textureKey);
+    this.boxSprite = scene.add.sprite(0, 0, textureKey);
+    this.boxSprite.setOrigin(0.5, 0.5);
+  }
+
+  private createIcon(scene: Scene): void {
+    this.iconText = new IconText({
+      scene,
+      x: 0,
+      y: 0,
+      icon: this.iconKey,
+      size: this.sizePx,
+      style: { color: this.iconColorValue },
+    });
+    this.iconText.setFontStyle('900');
+    this.iconText.setOrigin(0.5, 0.5);
+    scene.add.existing(this.iconText);
+    // Start hidden if unchecked, visible if checked.
+    if (!this.checkedState) {
+      this.iconText.setAlpha(0);
+      this.iconText.setScale(0);
+    }
+  }
+
+  private createLabel(scene: Scene): void {
+    if (this.labelValue === undefined || this.labelValue === '') return;
+    this.labelText = new Text({
+      scene,
+      x: 0,
+      y: 0,
+      text: this.labelValue,
+      size: this.sizePx,
+      fontFamily: 'Fredoka',
+      strokeThickness: 0,
+      strokeColor: 'rgba(0,0,0,0)',
+    });
+    this.labelText.setColor(this.labelColorValue);
+    this.labelText.setOrigin(0.5, 0.5);
+  }
+
+  private createHitRect(scene: Scene): void {
+    // Rectangle sized to (box + labelGap + label) so clicks on the label
+    // toggle too. We update its size in syncSize after we know the actual
+    // width.
+    this.hitRect = scene.add.rectangle(
+      0,
+      0,
+      this.boxSidePx,
+      this.boxSidePx,
+      0x000000,
+      0
+    );
+    this.hitRect.setOrigin(0.5, 0.5);
+  }
+
+  private setupContainer(): void {
+    // Compose box + icon into a single "checkbox unit" container so a Stack
+    // can measure it as one item.
+    const boxUnit = this.scene.add.container(0, 0, [
+      this.boxSprite,
+      this.iconText,
+    ]);
+    boxUnit.setSize(this.boxSidePx, this.boxSidePx);
+
+    const children: GameObjects.GameObject[] = [boxUnit];
+    if (this.labelText) children.push(this.labelText);
+
+    // Outer horizontal layout — box + optional label.
+    const contentStack = new Stack({
+      scene: this.scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap: this.labelGap,
+      children,
+    });
+
+    // Z-order: hit rect first (behind, transparent), then the visible content.
+    this.add([this.hitRect, contentStack]);
+  }
+
+  private setupInteractivity(): void {
+    this.hitRect.setInteractive({ useHandCursor: true });
+    this.hitRect.on('pointerdown', () => {
+      if (this.disabledState || this.readOnlyState) return;
+      this.onClickCb?.();
+      this.toggle();
+    });
+  }
+
+  private syncSize(): void {
+    // Width: box + (labelGap + label) if any. Height: max of box and label.
+    const labelBounds = this.labelText?.getBounds();
+    const labelWidth = labelBounds?.width ?? 0;
+    const labelHeight = labelBounds?.height ?? 0;
+    const totalWidth =
+      this.boxSidePx + (this.labelText ? this.labelGap + labelWidth : 0);
+    const totalHeight = Math.max(this.boxSidePx, labelHeight);
+    // Resize the hit target to cover the whole clickable area.
+    this.hitRect.setSize(totalWidth, totalHeight);
+    // ContainerInteractive proxies our width/height to the hitRect, so a
+    // parent Row/Column/Stack measures this checkbox correctly.
+    this.setSize(totalWidth, totalHeight);
+  }
+
+  private applyDisabledVisual(): void {
+    const targetAlpha = this.disabledState ? DISABLED_ALPHA : 1;
+    this.boxSprite.setAlpha(targetAlpha);
+    this.iconText.setAlpha(this.checkedState ? targetAlpha : 0);
+    if (this.labelText) this.labelText.setAlpha(targetAlpha);
+  }
+
+  private animateIcon(toChecked: boolean): void {
+    // Kill any in-flight tween on the icon so rapid toggles don't stack.
+    this.scene.tweens.killTweensOf(this.iconText);
+    const targetAlpha = toChecked ? (this.disabledState ? DISABLED_ALPHA : 1) : 0;
+    const targetScale = toChecked ? 1 : 0;
+    this.scene.tweens.add({
+      targets: this.iconText,
+      alpha: targetAlpha,
+      scaleX: targetScale,
+      scaleY: targetScale,
+      duration: toChecked
+        ? CHECK_TWEEN_DURATION_MS
+        : UNCHECK_TWEEN_DURATION_MS,
+      ease: toChecked ? CHECK_TWEEN_EASE : UNCHECK_TWEEN_EASE,
+    });
+  }
+
+  private getBoxTextureKey(): string {
+    return `checkbox_box_${this.colorInput}_${this.borderRadiusPx}_${this.boxSidePx}_${this.checkedState ? 'on' : 'off'}`;
+  }
+
+  private drawBoxTexture(scene: Scene, textureKey: string): void {
+    if (scene.textures.exists(textureKey)) return;
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
+    const textureSide = this.boxSidePx + padding * 2;
+
+    const graphics = scene.add.graphics();
+    const maxRadius = Math.floor(this.boxSidePx / 2);
+    const radius = Math.min(this.borderRadiusPx, maxRadius);
+
+    if (this.checkedState) {
+      // Filled with color.
+      graphics.fillStyle(this.colorFilled, 1);
+      graphics.fillRoundedRect(
+        padding,
+        padding,
+        this.boxSidePx,
+        this.boxSidePx,
+        radius
+      );
+    } else {
+      // Outlined — colored border inset by half the stroke so the outer edge
+      // sits at the visual box boundary.
+      const half = BOX_BORDER_THICKNESS / 2;
+      graphics.lineStyle(BOX_BORDER_THICKNESS, this.colorFilled, 1);
+      graphics.strokeRoundedRect(
+        padding + half,
+        padding + half,
+        this.boxSidePx - BOX_BORDER_THICKNESS,
+        this.boxSidePx - BOX_BORDER_THICKNESS,
+        Math.max(0, radius - half)
+      );
+      // Subtle translucent fill so the empty box is still readable on any bg.
+      graphics.fillStyle(this.colorFilled, Opacity.value('10'));
+      graphics.fillRoundedRect(
+        padding,
+        padding,
+        this.boxSidePx,
+        this.boxSidePx,
+        radius
+      );
+    }
+
+    graphics.generateTexture(textureKey, textureSide, textureSide);
+    graphics.destroy();
+  }
+
+  private regenerateBoxTexture(): void {
+    const textureKey = this.getBoxTextureKey();
+    this.drawBoxTexture(this.scene, textureKey);
+    this.boxSprite.setTexture(textureKey);
+  }
+}

--- a/packages/hudini/src/components/checkbox/index.ts
+++ b/packages/hudini/src/components/checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from './checkbox';

--- a/packages/hudini/src/components/dock/dock.spec.ts
+++ b/packages/hudini/src/components/dock/dock.spec.ts
@@ -14,7 +14,14 @@ vi.mock('../../utils/get-pw-from-scene', () => ({
   getPWFromScene: vi.fn(() => ({
     fontSize: {
       px: vi.fn((key: string) => {
-        const map: Record<string, number> = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 };
+        const map: Record<string, number> = {
+          xs: 12,
+          sm: 14,
+          base: 16,
+          lg: 18,
+          xl: 20,
+          '2xl': 24,
+        };
         return map[key] ?? 16;
       }),
     },
@@ -68,8 +75,20 @@ vi.mock('phaser', () => {
   }
   class MockRectangle {
     public listeners: Record<string, Array<() => void>> = {};
-    // eslint-disable-next-line no-unused-vars
-    constructor(_x: number, _y: number, _w: number, _h: number, _c: number, _a: number) {}
+    constructor(
+      // eslint-disable-next-line no-unused-vars
+      _x: number,
+      // eslint-disable-next-line no-unused-vars
+      _y: number,
+      // eslint-disable-next-line no-unused-vars
+      _w: number,
+      // eslint-disable-next-line no-unused-vars
+      _h: number,
+      // eslint-disable-next-line no-unused-vars
+      _c: number,
+      // eslint-disable-next-line no-unused-vars
+      _a: number
+    ) {}
     setOrigin(): this {
       return this;
     }
@@ -81,7 +100,7 @@ vi.mock('phaser', () => {
       return this;
     }
     emit(evt: string): this {
-      (this.listeners[evt] ?? []).forEach((cb) => cb());
+      (this.listeners[evt] ?? []).forEach(cb => cb());
       return this;
     }
   }
@@ -112,12 +131,18 @@ vi.mock('phaser', () => {
   class Scene {
     add = {
       existing: vi.fn(),
-      text: vi.fn((x: number, y: number, t: string, s: unknown) => new MockText(x, y, t, s)),
+      text: vi.fn(
+        (x: number, y: number, t: string, s: unknown) =>
+          new MockText(x, y, t, s)
+      ),
       rectangle: vi.fn(
         (x: number, y: number, w: number, h: number, c: number, a: number) =>
           new MockRectangle(x, y, w, h, c, a)
       ),
-      container: vi.fn((x: number, y: number, children: unknown[]) => new MockInnerContainer(x, y, children)),
+      container: vi.fn(
+        (x: number, y: number, children: unknown[]) =>
+          new MockInnerContainer(x, y, children)
+      ),
     };
   }
   const GameObjects = { Container };

--- a/packages/hudini/src/components/dock/dock.ts
+++ b/packages/hudini/src/components/dock/dock.ts
@@ -17,10 +17,13 @@ import { Stack } from '../stack';
 export type DockItem = {
   /** Unique identifier passed back to `onSelect`. */
   id: string;
-  /** Font Awesome icon key to render above the label. */
+  /** Font Awesome icon key to render above the label (or alone if no label). */
   icon: IconKey;
-  /** Text shown under the icon. */
-  label: string;
+  /**
+   * Optional text shown under the icon. When omitted, the item renders as
+   * icon-only — useful for minimalist docks / toolbars.
+   */
+  label?: string;
 };
 
 /**
@@ -79,7 +82,8 @@ export type DockParams = {
 
 type DockItemVisual = {
   icon: IconText;
-  label: GameObjects.Text;
+  /** Undefined when the item was created without a label (icon-only). */
+  label: GameObjects.Text | undefined;
   container: GameObjects.Container;
 };
 
@@ -229,14 +233,21 @@ export class Dock extends GameObjects.Container {
     iconText.setOrigin(0.5, 0.5);
     scene.add.existing(iconText);
 
-    const label = scene.add.text(0, 0, item.label, {
-      fontFamily: 'Fredoka',
-      fontSize: `${this.labelSizePx}px`,
-      color: initialColor,
-    });
-    label.setOrigin(0.5, 0.5);
+    // Label is optional — icon-only items just skip building it.
+    let label: GameObjects.Text | undefined;
+    if (item.label !== undefined && item.label !== '') {
+      label = scene.add.text(0, 0, item.label, {
+        fontFamily: 'Fredoka',
+        fontSize: `${this.labelSizePx}px`,
+        color: initialColor,
+      });
+      label.setOrigin(0.5, 0.5);
+    }
 
-    // Icon+label as a vertical Stack (pure layout, no bg).
+    // Icon(+label) as a vertical Stack (pure layout, no bg).
+    const columnChildren: GameObjects.GameObject[] = label
+      ? [iconText, label]
+      : [iconText];
     const column = new Stack({
       scene,
       x: 0,
@@ -244,7 +255,7 @@ export class Dock extends GameObjects.Container {
       direction: 'column',
       gap: ICON_LABEL_GAP,
       align: 'center',
-      children: [iconText, label],
+      children: columnChildren,
     });
 
     // Widen the click target beyond the visible column footprint.
@@ -277,6 +288,6 @@ export class Dock extends GameObjects.Container {
     const isActive = itemId === this.activeId;
     const c = isActive ? this.activeColorValue : this.inactiveColorValue;
     visual.icon.setColor(c);
-    visual.label.setColor(c);
+    visual.label?.setColor(c);
   }
 }

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './alert';
 export * from './badge';
 export * from './card';
+export * from './checkbox';
 export * from './circular-progress';
 export * from './container-interactive';
 export * from './dock';

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -9,6 +9,8 @@ export * from './icon-button';
 export * from './linear-progress';
 export * from './panel';
 export * from './radial-progress';
+export * from './radio';
+export * from './radio-group';
 export * from './sized-box';
 export * from './stack';
 export * from './toggle';

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './alert';
 export * from './badge';
 export * from './card';
 export * from './circular-progress';

--- a/packages/hudini/src/components/index.ts
+++ b/packages/hudini/src/components/index.ts
@@ -11,6 +11,7 @@ export * from './panel';
 export * from './radial-progress';
 export * from './sized-box';
 export * from './stack';
+export * from './toggle';
 export * from './text';
 export * from './text-button';
 

--- a/packages/hudini/src/components/radio-group/index.ts
+++ b/packages/hudini/src/components/radio-group/index.ts
@@ -1,0 +1,1 @@
+export * from './radio-group';

--- a/packages/hudini/src/components/radio-group/radio-group.spec.ts
+++ b/packages/hudini/src/components/radio-group/radio-group.spec.ts
@@ -1,0 +1,249 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable sonarjs/no-identical-functions */
+import { describe, expect, it, vi } from 'vitest';
+
+import { RadioGroup } from './radio-group';
+
+/**
+ * We mock the Radio class here — RadioGroup's responsibility is only the
+ * "only one selected" invariant + defaults propagation. The actual visual
+ * Radio is tested in ../radio/radio.spec.ts.
+ */
+vi.mock('../radio', () => {
+  class Radio {
+    public readonly value: string | undefined;
+    public name: string | undefined;
+    private checkedState: boolean;
+    private disabledState: boolean;
+    private readOnlyState: boolean;
+    private onChangeCb:
+      | ((checked: boolean, value?: string, name?: string) => void)
+      | undefined;
+
+    constructor(params: {
+      value?: string;
+      name?: string;
+      checked?: boolean;
+      disabled?: boolean;
+      readOnly?: boolean;
+      onChange?: (
+        checked: boolean,
+        value?: string,
+        name?: string
+      ) => void;
+    }) {
+      this.value = params.value;
+      this.name = params.name;
+      this.checkedState = params.checked ?? false;
+      this.disabledState = params.disabled ?? false;
+      this.readOnlyState = params.readOnly ?? false;
+      this.onChangeCb = params.onChange;
+    }
+
+    setChecked(v: boolean): this {
+      if (this.checkedState === v) return this;
+      this.checkedState = v;
+      this.onChangeCb?.(v, this.value, this.name);
+      return this;
+    }
+
+    select(): this {
+      return this.setChecked(true);
+    }
+
+    isChecked(): boolean {
+      return this.checkedState;
+    }
+
+    getValue(): boolean {
+      return this.checkedState;
+    }
+
+    setDisabled(v: boolean): this {
+      this.disabledState = v;
+      return this;
+    }
+
+    isDisabled(): boolean {
+      return this.disabledState;
+    }
+
+    setReadOnly(v: boolean): this {
+      this.readOnlyState = v;
+      return this;
+    }
+
+    isReadOnly(): boolean {
+      return this.readOnlyState;
+    }
+  }
+  return { Radio };
+});
+
+const fakeScene = {} as never;
+
+describe('RadioGroup', () => {
+  it('should start with the initial value selected', () => {
+    const group = new RadioGroup({
+      scene: fakeScene,
+      value: 'normal',
+    });
+    const easy = group.createRadio({ x: 0, y: 0, value: 'easy' });
+    const normal = group.createRadio({ x: 0, y: 0, value: 'normal' });
+    const hard = group.createRadio({ x: 0, y: 0, value: 'hard' });
+
+    expect(group.getValue()).toBe('normal');
+    expect(easy.isChecked()).toBe(false);
+    expect(normal.isChecked()).toBe(true);
+    expect(hard.isChecked()).toBe(false);
+  });
+
+  it('should deselect the previous radio when another is selected', () => {
+    const group = new RadioGroup({ scene: fakeScene, value: 'a' });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    b.select();
+    expect(a.isChecked()).toBe(false);
+    expect(b.isChecked()).toBe(true);
+    expect(group.getValue()).toBe('b');
+  });
+
+  it('should fire onChange when the selection changes (once per change)', () => {
+    const calls: Array<[string | undefined, string | undefined]> = [];
+    const group = new RadioGroup({
+      scene: fakeScene,
+      name: 'diff',
+      onChange: (v, n): void => {
+        calls.push([v, n]);
+      },
+    });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    a.select();
+    b.select();
+    expect(calls).toEqual([
+      ['a', 'diff'],
+      ['b', 'diff'],
+    ]);
+  });
+
+  it('should NOT fire onChange when selecting the already-selected value', () => {
+    let calls = 0;
+    const group = new RadioGroup({
+      scene: fakeScene,
+      value: 'a',
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    a.select();
+    expect(calls).toBe(0);
+  });
+
+  it('should set value programmatically via setValue', () => {
+    const group = new RadioGroup({ scene: fakeScene });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    group.setValue('b');
+    expect(a.isChecked()).toBe(false);
+    expect(b.isChecked()).toBe(true);
+    expect(group.getValue()).toBe('b');
+  });
+
+  it('should clear the value when passed undefined', () => {
+    const group = new RadioGroup({ scene: fakeScene, value: 'a' });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+
+    group.setValue(undefined);
+    expect(a.isChecked()).toBe(false);
+    expect(group.getValue()).toBeUndefined();
+  });
+
+  it('should not recurse when internally deselecting siblings', () => {
+    let calls = 0;
+    const group = new RadioGroup({
+      scene: fakeScene,
+      value: 'a',
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    b.select();
+    // Only the group's onChange fires — the "a → false" propagated from the
+    // group's internal update is muted by the recursion guard.
+    expect(calls).toBe(1);
+  });
+
+  it('should propagate defaults to each Radio unless overridden', () => {
+    const group = new RadioGroup({
+      scene: fakeScene,
+      color: 'purple-600',
+      name: 'diff',
+    });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    // Radio inherited the name.
+    expect(a.name).toBe('diff');
+  });
+
+  it('should allow per-radio overrides on createRadio', () => {
+    const group = new RadioGroup({
+      scene: fakeScene,
+      color: 'purple-600',
+    });
+    const overridden = group.createRadio({
+      x: 0,
+      y: 0,
+      value: 'a',
+      color: 'red-500',
+    });
+    // Just make sure it constructed — we don't introspect color internals here.
+    expect(overridden.value).toBe('a');
+  });
+
+  it('should disable / enable every radio in the group', () => {
+    const group = new RadioGroup({ scene: fakeScene });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    group.disable();
+    expect(a.isDisabled()).toBe(true);
+    expect(b.isDisabled()).toBe(true);
+
+    group.enable();
+    expect(a.isDisabled()).toBe(false);
+    expect(b.isDisabled()).toBe(false);
+  });
+
+  it('should apply readOnly to every radio', () => {
+    const group = new RadioGroup({ scene: fakeScene });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    const b = group.createRadio({ x: 0, y: 0, value: 'b' });
+
+    group.setReadOnly(true);
+    expect(a.isReadOnly()).toBe(true);
+    expect(b.isReadOnly()).toBe(true);
+    expect(group.isReadOnly()).toBe(true);
+  });
+
+  it('should allow replacing the onChange callback', () => {
+    const group = new RadioGroup({ scene: fakeScene });
+    const a = group.createRadio({ x: 0, y: 0, value: 'a' });
+    let calls = 0;
+    group.onChange((): void => {
+      calls++;
+    });
+    a.select();
+    expect(calls).toBe(1);
+    group.onChange(undefined);
+    group.setValue('a-again' as never);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/hudini/src/components/radio-group/radio-group.ts
+++ b/packages/hudini/src/components/radio-group/radio-group.ts
@@ -1,0 +1,242 @@
+import { type IconKey } from 'font-awesome-for-phaser';
+import { type Scene } from 'phaser';
+import { type ColorKey, type FontSizeKey, type RadiusKey } from 'phaser-wind';
+
+import { Radio, type RadioParams } from '../radio';
+
+/** Parameters for creating a {@link RadioGroup}. */
+export type RadioGroupParams = {
+  /** Phaser scene shared by all radios in this group. */
+  scene: Scene;
+  /**
+   * Metadata that identifies this group (passed back as the 2nd arg of
+   * `onChange`). Not used to auto-link anything — no global registry.
+   */
+  name?: string;
+  /** Initially selected value. Radios matching this `value` will be checked. */
+  value?: string;
+  /** Disables every radio in the group. */
+  disabled?: boolean;
+  /** Marks every radio in the group as read-only (visible, ignores clicks). */
+  readOnly?: boolean;
+  /** Fires when the selected value changes. */
+  onChange?: (value: string | undefined, name?: string) => void;
+
+  // ---- Shared defaults applied to every Radio created via createRadio.
+  // ---- Per-call params in `createRadio` override these.
+
+  /** Default color for all radios in the group. */
+  color?: ColorKey | string;
+  /** Default icon for all radios in the group. */
+  icon?: IconKey;
+  /** Default icon color for all radios. */
+  iconColor?: ColorKey | string;
+  /** Default label color for all radios. */
+  labelColor?: ColorKey | string;
+  /** Default size for all radios. */
+  size?: FontSizeKey | number;
+  /** Default border radius for all radios. */
+  borderRadius?: RadiusKey | number;
+};
+
+/**
+ * Params for {@link RadioGroup.createRadio}. Same shape as {@link RadioParams}
+ * minus the fields the group manages (`onChange` is intercepted; `checked` is
+ * derived from the group's `value`).
+ *
+ * Every field the group has as a default can still be overridden here.
+ */
+export type RadioGroupCreateRadioParams = Omit<
+  RadioParams,
+  'scene' | 'checked' | 'onChange'
+>;
+
+/**
+ * RadioGroup — a controller for a set of {@link Radio}s that enforces
+ * "only one selected". Not a visual component — nothing renders. It exposes
+ * a `createRadio(params)` factory; the returned Radios can be positioned
+ * anywhere in the scene (inside a Stack, spread across a HUD, wherever).
+ *
+ * The group holds the "selected value" and ensures that whenever any radio
+ * flips to checked, the previously selected radio is deselected.
+ *
+ * @example
+ * const group = new RadioGroup({
+ *   scene: this,
+ *   name: 'difficulty',
+ *   value: 'normal',
+ *   color: 'blue-500',
+ *   onChange: (value) => console.log('selected:', value),
+ * });
+ *
+ * const easy   = group.createRadio({ x: 200, y: 100, value: 'easy',   label: 'Easy' });
+ * const normal = group.createRadio({ x: 200, y: 150, value: 'normal', label: 'Normal' });
+ * const hard   = group.createRadio({ x: 200, y: 200, value: 'hard',   label: 'Hard' });
+ *
+ * this.add.existing(easy);
+ * this.add.existing(normal);
+ * this.add.existing(hard);
+ *
+ * group.getValue(); // 'normal'
+ * group.setValue('hard');
+ */
+export class RadioGroup {
+  /** All radios created by this group's factory. Read-only for consumers. */
+  public readonly radios: Radio[] = [];
+  /** The group's name — passed back as the 2nd arg of `onChange`. */
+  public readonly groupName: string | undefined;
+
+  private readonly scene: Scene;
+  private readonly defaults: Omit<RadioGroupParams, 'scene' | 'name' | 'value' | 'onChange'>;
+  private currentValue: string | undefined;
+  private disabledState: boolean;
+  private readOnlyState: boolean;
+  private onChangeCb:
+    | ((value: string | undefined, name?: string) => void)
+    | undefined;
+  /**
+   * Guard against recursion: when we call setChecked(false) on the "losing"
+   * radios, we don't want their onChange handlers to feed back into the
+   * group.
+   */
+  private updating = false;
+
+  constructor(params: RadioGroupParams) {
+    const {
+      scene,
+      name,
+      value,
+      disabled = false,
+      readOnly = false,
+      onChange,
+      ...defaults
+    } = params;
+
+    this.scene = scene;
+    this.groupName = name;
+    this.currentValue = value;
+    this.disabledState = disabled;
+    this.readOnlyState = readOnly;
+    this.onChangeCb = onChange;
+    this.defaults = defaults;
+  }
+
+  // -------- factory --------
+
+  /**
+   * Create a Radio wired to this group. The Radio is checked automatically
+   * if its `value` matches the group's current value.
+   *
+   * @param params Radio configuration. Any of the group-level defaults
+   *   (`color`, `icon`, `size`, etc.) can be overridden here per-radio.
+   */
+  public createRadio(params: RadioGroupCreateRadioParams): Radio {
+    // Pass the group's name through so `onChange` on the RADIO also reports
+    // the form field (matches Checkbox/Toggle behavior). `exactOptionalPropertyTypes`
+    // makes us conditionally spread — can't pass `undefined` into an optional slot.
+    const effectiveName = params.name ?? this.groupName;
+
+    // Merge group defaults with per-radio overrides. Per-radio wins.
+    const merged: RadioParams = {
+      ...this.defaults,
+      ...params,
+      scene: this.scene,
+      // Derived: checked iff this radio's value matches the group's.
+      checked: params.value !== undefined && params.value === this.currentValue,
+      // Inherit group-level disabled/readOnly unless the radio overrides.
+      disabled: params.disabled ?? this.disabledState,
+      readOnly: params.readOnly ?? this.readOnlyState,
+      ...(effectiveName !== undefined && { name: effectiveName }),
+      // Intercept the change: any radio going true means it's the new value.
+      onChange: (checked, value): void => {
+        if (this.updating) return;
+        if (checked && value !== undefined) {
+          this.setValue(value);
+        } else if (!checked && value === this.currentValue) {
+          // Radio was programmatically deselected AND it was the current
+          // selection. Group's current value goes to undefined.
+          this.setValue(undefined);
+        }
+      },
+    };
+
+    const radio = new Radio(merged);
+    this.radios.push(radio);
+    return radio;
+  }
+
+  // -------- public API --------
+
+  /**
+   * Programmatically set the selected value. Fires `onChange` on the group
+   * if the value changes.
+   */
+  public setValue(value: string | undefined): this {
+    if (this.currentValue === value) return this;
+    this.currentValue = value;
+    // Sync every radio to the new selection (silently to avoid recursion).
+    this.updating = true;
+    try {
+      this.radios.forEach((radio) => {
+        radio.setChecked(radio.value !== undefined && radio.value === value);
+      });
+    } finally {
+      this.updating = false;
+    }
+    this.onChangeCb?.(value, this.groupName);
+    return this;
+  }
+
+  /** The value of the currently selected radio, or `undefined`. */
+  public getValue(): string | undefined {
+    return this.currentValue;
+  }
+
+  /** Disable / enable every radio in the group. */
+  public setDisabled(disabled: boolean): this {
+    this.disabledState = disabled;
+    this.radios.forEach((radio) => radio.setDisabled(disabled));
+    return this;
+  }
+
+  public disable(): this {
+    return this.setDisabled(true);
+  }
+
+  public enable(): this {
+    return this.setDisabled(false);
+  }
+
+  public isDisabled(): boolean {
+    return this.disabledState;
+  }
+
+  /** Mark every radio as read-only (or clear it). */
+  public setReadOnly(readOnly: boolean): this {
+    this.readOnlyState = readOnly;
+    this.radios.forEach((radio) => radio.setReadOnly(readOnly));
+    return this;
+  }
+
+  public isReadOnly(): boolean {
+    return this.readOnlyState;
+  }
+
+  /** Replace the group's onChange callback. */
+  public onChange(
+    cb: ((value: string | undefined, name?: string) => void) | undefined
+  ): this {
+    this.onChangeCb = cb;
+    return this;
+  }
+
+  /**
+   * Clear this group's registry. Does NOT destroy the individual Radios —
+   * they remain in the scene and continue to function standalone. Call
+   * `radio.destroy()` on each if you want to remove them too.
+   */
+  public destroy(): void {
+    this.radios.length = 0;
+    this.onChangeCb = undefined;
+  }
+}

--- a/packages/hudini/src/components/radio/index.ts
+++ b/packages/hudini/src/components/radio/index.ts
@@ -1,0 +1,1 @@
+export * from './radio';

--- a/packages/hudini/src/components/radio/radio.spec.ts
+++ b/packages/hudini/src/components/radio/radio.spec.ts
@@ -1,0 +1,397 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable max-lines */
+/* eslint-disable sonarjs/no-identical-functions */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+    setScale(): this {
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 40;
+    public height = 20;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    layout(): void {
+      /* noop */
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
+vi.mock('phaser-wind', () => ({
+  Color: {
+    rgb: vi.fn((color: string) => `rgb-${color}`),
+    hex: vi.fn(() => 0x3b82f6),
+  },
+  Opacity: {
+    value: vi.fn(() => 0.1),
+  },
+}));
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    fontSize: {
+      px: vi.fn((size: string) => {
+        const sizes = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+        return sizes[size as keyof typeof sizes] || 16;
+      }),
+    },
+    radius: {
+      px: vi.fn(() => 9999),
+    },
+  })),
+}));
+
+vi.mock('../text', () => {
+  class MockText {
+    private text: string;
+    // eslint-disable-next-line no-unused-vars
+    constructor(params: { text: string }) {
+      this.text = params.text;
+    }
+    setText(t: string): this {
+      this.text = t;
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+    getBounds(): { width: number; height: number } {
+      return { width: this.text.length * 10, height: 18 };
+    }
+  }
+  return { Text: MockText };
+});
+
+vi.mock('phaser', () => {
+  class MockSprite {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _texture: string) {}
+    setOrigin(): this {
+      return this;
+    }
+    setTexture(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+  }
+  class MockRectangle {
+    public width = 0;
+    public height = 0;
+    public listeners: Record<string, Array<() => void>> = {};
+    constructor(
+      _x: number,
+      _y: number,
+      w: number,
+      h: number,
+      // eslint-disable-next-line no-unused-vars
+      _c: number,
+      // eslint-disable-next-line no-unused-vars
+      _a: number
+    ) {
+      this.width = w;
+      this.height = h;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setInteractive(): this {
+      return this;
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+    on(evt: string, cb: () => void): this {
+      (this.listeners[evt] ||= []).push(cb);
+      return this;
+    }
+    emit(evt: string): this {
+      (this.listeners[evt] ?? []).forEach((cb) => cb());
+      return this;
+    }
+  }
+  class MockGraphics {
+    fillStyle(): this {
+      return this;
+    }
+    fillRoundedRect(): this {
+      return this;
+    }
+    lineStyle(): this {
+      return this;
+    }
+    strokeRoundedRect(): this {
+      return this;
+    }
+    generateTexture(): this {
+      return this;
+    }
+    destroy(): this {
+      return this;
+    }
+  }
+  class MockInnerContainer {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _children: unknown[]) {}
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  class Container {
+    scene: Scene;
+    list: unknown[] = [];
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    remove(): this {
+      return this;
+    }
+    addAt(): this {
+      return this;
+    }
+    setSize(): this {
+      return this;
+    }
+  }
+  class Scene {
+    tweens = {
+      add: vi.fn(),
+      killTweensOf: vi.fn(),
+    };
+    textures = {
+      exists: vi.fn(() => false),
+    };
+    add = {
+      existing: vi.fn(),
+      sprite: vi.fn(
+        (x: number, y: number, texture: string) =>
+          new MockSprite(x, y, texture)
+      ),
+      rectangle: vi.fn(
+        (
+          x: number,
+          y: number,
+          w: number,
+          h: number,
+          c: number,
+          a: number
+        ) => new MockRectangle(x, y, w, h, c, a)
+      ),
+      graphics: vi.fn(() => new MockGraphics()),
+      container: vi.fn(
+        (x: number, y: number, children: unknown[]) =>
+          new MockInnerContainer(x, y, children)
+      ),
+    };
+  }
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Radio } from './radio';
+
+describe('Radio', () => {
+  it('should default to unchecked', () => {
+    const scene = new Scene();
+    const r = new Radio({ scene, x: 0, y: 0 });
+    expect(r.getValue()).toBe(false);
+    expect(r.isChecked()).toBe(false);
+  });
+
+  it('should expose the value prop', () => {
+    const scene = new Scene();
+    const r = new Radio({ scene, x: 0, y: 0, value: 'easy' });
+    expect(r.value).toBe('easy');
+  });
+
+  it('should select via select() (idempotent)', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    r.select();
+    expect(r.isChecked()).toBe(true);
+    expect(calls).toBe(1);
+    r.select();
+    expect(r.isChecked()).toBe(true);
+    expect(calls).toBe(1); // no double fire
+  });
+
+  it('should deselect only via setChecked(false), never via click', () => {
+    const scene = new Scene();
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      checked: true,
+    });
+    // Simulate click on an already-selected radio.
+    (r.hitRect as unknown as { emit: (e: string) => void }).emit(
+      'pointerdown'
+    );
+    expect(r.isChecked()).toBe(true); // still selected
+    // Programmatic deselect works.
+    r.setChecked(false);
+    expect(r.isChecked()).toBe(false);
+  });
+
+  it('should fire onChange with checked, value, name', () => {
+    const scene = new Scene();
+    const calls: Array<[boolean, string | undefined, string | undefined]> =
+      [];
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      value: 'easy',
+      name: 'difficulty',
+      onChange: (c, v, n): void => {
+        calls.push([c, v, n]);
+      },
+    });
+    r.select();
+    expect(calls).toEqual([[true, 'easy', 'difficulty']]);
+  });
+
+  it('should ignore clicks when disabled', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      disabled: true,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    (r.hitRect as unknown as { emit: (e: string) => void }).emit(
+      'pointerdown'
+    );
+    expect(calls).toBe(0);
+    expect(r.getValue()).toBe(false);
+  });
+
+  it('should ignore clicks when readOnly but allow programmatic setChecked', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      readOnly: true,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    (r.hitRect as unknown as { emit: (e: string) => void }).emit(
+      'pointerdown'
+    );
+    expect(calls).toBe(0);
+    r.setChecked(true);
+    expect(calls).toBe(1);
+  });
+
+  it('should support disable/enable', () => {
+    const scene = new Scene();
+    const r = new Radio({ scene, x: 0, y: 0 });
+    r.disable();
+    expect(r.isDisabled()).toBe(true);
+    r.enable();
+    expect(r.isDisabled()).toBe(false);
+  });
+
+  it('should support setReadOnly / isReadOnly', () => {
+    const scene = new Scene();
+    const r = new Radio({ scene, x: 0, y: 0 });
+    r.setReadOnly(true);
+    expect(r.isReadOnly()).toBe(true);
+  });
+
+  it('should allow replacing the onChange callback', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const r = new Radio({ scene, x: 0, y: 0 });
+    r.onChange((): void => {
+      calls++;
+    });
+    r.select();
+    expect(calls).toBe(1);
+    r.onChange(undefined);
+    r.setChecked(false);
+    expect(calls).toBe(1);
+  });
+
+  it('should fire onClick even when the state does not change (already selected)', () => {
+    const scene = new Scene();
+    let clicks = 0;
+    const r = new Radio({
+      scene,
+      x: 0,
+      y: 0,
+      checked: true,
+      onClick: (): void => {
+        clicks++;
+      },
+    });
+    (r.hitRect as unknown as { emit: (e: string) => void }).emit(
+      'pointerdown'
+    );
+    expect(clicks).toBe(1);
+    expect(r.isChecked()).toBe(true);
+  });
+});

--- a/packages/hudini/src/components/radio/radio.ts
+++ b/packages/hudini/src/components/radio/radio.ts
@@ -1,0 +1,478 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
+/* eslint-disable max-lines */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
+import { GameObjects, Scene } from 'phaser';
+import {
+  Color,
+  Opacity,
+  PhaserWindPlugin,
+  type ColorKey,
+  type FontSizeKey,
+  type RadiusKey,
+} from 'phaser-wind';
+
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { ContainerInteractive } from '../container-interactive';
+import { Stack } from '../stack';
+import { Text } from '../text';
+
+/** Parameters for creating a {@link Radio}. */
+export type RadioParams = {
+  /** Phaser scene where the radio will be added. */
+  scene: Scene;
+  /** X position (center of the whole content — box + label). */
+  x: number;
+  /** Y position (center of the whole content). */
+  y: number;
+  /**
+   * Unique identifier within a `RadioGroup`. Optional when the Radio is used
+   * standalone (the value is only meaningful within a group).
+   */
+  value?: string;
+  /** Initial checked state. Default `false`. */
+  checked?: boolean;
+  /** Muted + non-interactive when `true`. Default `false`. */
+  disabled?: boolean;
+  /** Visually normal but ignores clicks when `true`. Default `false`. */
+  readOnly?: boolean;
+  /** Optional metadata passed back as the 2nd arg of `onChange`. */
+  name?: string;
+  /** Optional text label to the right of the circle. */
+  label?: string;
+  /**
+   * Font Awesome icon shown inside the circle when checked. Default
+   * `'circle'` (a solid dot — classic radio look). Use any FA key for a
+   * game-flavored radio (e.g. `'heart'`, `'star'`, `'skull'`).
+   */
+  icon?: IconKey;
+  /**
+   * Icon size in pixels. Default is proportional to `size` (~55%), which
+   * renders as a small dot inside the circle. Increase for icon-heavy radios.
+   */
+  iconSize?: number;
+  /** Icon color. Default `'white'`. */
+  iconColor?: ColorKey | string;
+  /** Circle fill / border color. Default `'blue-500'`. */
+  color?: ColorKey | string;
+  /** Label text color. Default `'slate-800'`. */
+  labelColor?: ColorKey | string;
+  /**
+   * Reference size (drives the outer circle and the label font). Default
+   * `'base'` (16px). Circle side = `size + 8`.
+   */
+  size?: FontSizeKey | number;
+  /**
+   * Border radius. Default `'full'` (circular). Override for a "pill radio"
+   * or square filter-chip style.
+   */
+  borderRadius?: RadiusKey | number;
+  /** Gap between circle and label. Default 8. */
+  labelGap?: number;
+  /**
+   * Fires whenever the checked state changes. Second and third args are the
+   * Radio's `value` and `name` (both optional).
+   */
+  onChange?: (
+    checked: boolean,
+    value?: string,
+    name?: string
+  ) => void;
+  /** Fires on any click / tap, regardless of state change. */
+  onClick?: () => void;
+};
+
+const DEFAULT_SIZE_KEY: FontSizeKey = 'base';
+const DEFAULT_ICON: IconKey = 'circle';
+const DEFAULT_ICON_SIZE_RATIO = 0.55;
+const BOX_PADDING_PX = 4;
+const BOX_BORDER_THICKNESS = 2;
+const TEXTURE_ANTIALIAS_MARGIN = 1;
+const DEFAULT_LABEL_GAP = 8;
+const DISABLED_ALPHA = 0.4;
+const SELECT_TWEEN_DURATION_MS = 140;
+const SELECT_TWEEN_EASE = 'Back.easeOut';
+const DESELECT_TWEEN_DURATION_MS = 100;
+const DESELECT_TWEEN_EASE = 'Sine.easeIn';
+
+/**
+ * Radio — a single-selection form control.
+ *
+ * The Radio itself is a Checkbox-family component: uncontrolled state,
+ * `onChange` callback, `disabled` / `readOnly`, `getValue()`. It differs from
+ * Checkbox in ONE semantic: **click always selects, never deselects.** This
+ * matches native `<input type="radio">` and daisyUI's radio behavior.
+ *
+ * **Recommended usage: {@link RadioGroup}.** The group is a controller +
+ * factory that ensures only one Radio in the group is selected at a time.
+ * Using Radio standalone is supported, but you own the "only one" invariant
+ * yourself.
+ *
+ * @example
+ * // Standalone (rare — you manage state manually)
+ * const cb = new Radio({
+ *   scene, x, y, label: 'Opt in', value: 'yes',
+ *   onChange: (checked, value) => console.log(value, checked),
+ * });
+ *
+ * @example
+ * // Preferred: via RadioGroup factory
+ * const group = new RadioGroup({
+ *   scene, name: 'difficulty', value: 'normal',
+ *   onChange: (value) => console.log('selected:', value),
+ * });
+ * const easy = group.createRadio({ x, y, value: 'easy', label: 'Easy' });
+ */
+export class Radio extends ContainerInteractive<Phaser.GameObjects.Rectangle> {
+  /** The outer circle sprite (visible border / fill). */
+  public boxSprite!: GameObjects.Sprite;
+  /** The icon (dot by default) rendered inside the circle when checked. */
+  public iconText!: IconText;
+  /** Optional label text. */
+  public labelText: GameObjects.Text | undefined;
+  /** Invisible hit target covering circle + label. */
+  public hitRect!: GameObjects.Rectangle;
+  /** The Radio's value within a group. May be undefined when standalone. */
+  public readonly value: string | undefined;
+
+  private pw: PhaserWindPlugin<{}>;
+  private checkedState: boolean;
+  private disabledState: boolean;
+  private readOnlyState: boolean;
+  private sizePx!: number;
+  private boxSidePx!: number;
+  private iconSizePx!: number;
+  private borderRadiusPx!: number;
+  private colorInput!: string;
+  private colorFilled!: number;
+  private iconColorValue!: string;
+  private labelColorValue!: string;
+  private iconKey!: IconKey;
+  private labelValue: string | undefined;
+  private labelGap: number;
+  private onChangeCb:
+    | ((checked: boolean, value?: string, name?: string) => void)
+    | undefined;
+  private onClickCb: (() => void) | undefined;
+
+  constructor({
+    scene,
+    x,
+    y,
+    value,
+    checked = false,
+    disabled = false,
+    readOnly = false,
+    name,
+    label,
+    icon = DEFAULT_ICON,
+    iconSize,
+    iconColor = 'white',
+    color = 'blue-500',
+    labelColor = 'slate-800',
+    size = DEFAULT_SIZE_KEY,
+    borderRadius = 'full',
+    labelGap = DEFAULT_LABEL_GAP,
+    onChange,
+    onClick,
+  }: RadioParams) {
+    super({ scene, x, y });
+    this.pw = getPWFromScene(scene);
+
+    this.value = value;
+    this.checkedState = checked;
+    this.disabledState = disabled;
+    this.readOnlyState = readOnly;
+    if (name !== undefined) this.name = name;
+    this.labelValue = label;
+    this.iconKey = icon;
+    this.labelGap = labelGap;
+    this.onChangeCb = onChange;
+    this.onClickCb = onClick;
+
+    this.sizePx =
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? DEFAULT_SIZE_KEY);
+    this.boxSidePx = this.sizePx + BOX_PADDING_PX * 2;
+    this.iconSizePx =
+      iconSize ?? Math.round(this.sizePx * DEFAULT_ICON_SIZE_RATIO);
+
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('full' as RadiusKey));
+
+    this.colorInput = String(color);
+    this.colorFilled = Color.hex(color as ColorKey);
+    this.iconColorValue = Color.rgb(iconColor as ColorKey);
+    this.labelColorValue = Color.rgb(labelColor as ColorKey);
+
+    this.createBox(scene);
+    this.createIcon(scene);
+    this.createLabel(scene);
+    this.createHitRect(scene);
+    this.setupContainer();
+    this.hitArea = this.hitRect;
+
+    this.applyDisabledVisual();
+    this.setupInteractivity();
+    this.syncSize();
+  }
+
+  // -------- public API --------
+
+  /**
+   * Select this radio. Idempotent — if already checked, does nothing.
+   * This is what click does internally, exposed for programmatic use.
+   */
+  public select(): this {
+    return this.setChecked(true);
+  }
+
+  /**
+   * Force the checked state. Fires `onChange` if it changes. Unlike a
+   * Checkbox, click never invokes `setChecked(false)` — use this method to
+   * programmatically deselect.
+   */
+  public setChecked(checked: boolean): this {
+    if (this.checkedState === checked) return this;
+    this.checkedState = checked;
+    this.regenerateBoxTexture();
+    this.animateIcon(checked);
+    this.onChangeCb?.(
+      checked,
+      this.value,
+      this.name === '' ? undefined : this.name
+    );
+    return this;
+  }
+
+  public isChecked(): boolean {
+    return this.checkedState;
+  }
+
+  /** Alias for {@link isChecked} — form-style value read. */
+  public getValue(): boolean {
+    return this.checkedState;
+  }
+
+  public setDisabled(disabled: boolean): this {
+    if (this.disabledState === disabled) return this;
+    this.disabledState = disabled;
+    this.applyDisabledVisual();
+    return this;
+  }
+
+  public disable(): this {
+    return this.setDisabled(true);
+  }
+
+  public enable(): this {
+    return this.setDisabled(false);
+  }
+
+  public isDisabled(): boolean {
+    return this.disabledState;
+  }
+
+  public setReadOnly(readOnly: boolean): this {
+    this.readOnlyState = readOnly;
+    return this;
+  }
+
+  public isReadOnly(): boolean {
+    return this.readOnlyState;
+  }
+
+  public onChange(
+    cb: ((checked: boolean, value?: string, name?: string) => void) | undefined
+  ): this {
+    this.onChangeCb = cb;
+    return this;
+  }
+
+  public onClick(cb: (() => void) | undefined): this {
+    this.onClickCb = cb;
+    return this;
+  }
+
+  // -------- private --------
+
+  private createBox(scene: Scene): void {
+    const textureKey = this.getBoxTextureKey();
+    this.drawBoxTexture(scene, textureKey);
+    this.boxSprite = scene.add.sprite(0, 0, textureKey);
+    this.boxSprite.setOrigin(0.5, 0.5);
+  }
+
+  private createIcon(scene: Scene): void {
+    this.iconText = new IconText({
+      scene,
+      x: 0,
+      y: 0,
+      icon: this.iconKey,
+      size: this.iconSizePx,
+      style: { color: this.iconColorValue },
+    });
+    this.iconText.setFontStyle('900');
+    this.iconText.setOrigin(0.5, 0.5);
+    scene.add.existing(this.iconText);
+    if (!this.checkedState) {
+      this.iconText.setAlpha(0);
+      this.iconText.setScale(0);
+    }
+  }
+
+  private createLabel(scene: Scene): void {
+    if (this.labelValue === undefined || this.labelValue === '') return;
+    this.labelText = new Text({
+      scene,
+      x: 0,
+      y: 0,
+      text: this.labelValue,
+      size: this.sizePx,
+      fontFamily: 'Fredoka',
+      strokeThickness: 0,
+      strokeColor: 'rgba(0,0,0,0)',
+    });
+    this.labelText.setColor(this.labelColorValue);
+    this.labelText.setOrigin(0.5, 0.5);
+  }
+
+  private createHitRect(scene: Scene): void {
+    this.hitRect = scene.add.rectangle(
+      0,
+      0,
+      this.boxSidePx,
+      this.boxSidePx,
+      0x000000,
+      0
+    );
+    this.hitRect.setOrigin(0.5, 0.5);
+  }
+
+  private setupContainer(): void {
+    const boxUnit = this.scene.add.container(0, 0, [
+      this.boxSprite,
+      this.iconText,
+    ]);
+    boxUnit.setSize(this.boxSidePx, this.boxSidePx);
+
+    const children: GameObjects.GameObject[] = [boxUnit];
+    if (this.labelText) children.push(this.labelText);
+
+    const contentStack = new Stack({
+      scene: this.scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap: this.labelGap,
+      children,
+    });
+
+    this.add([this.hitRect, contentStack]);
+  }
+
+  private setupInteractivity(): void {
+    this.hitRect.setInteractive({ useHandCursor: true });
+    this.hitRect.on('pointerdown', () => {
+      if (this.disabledState || this.readOnlyState) return;
+      this.onClickCb?.();
+      // Click always selects — never deselects. Matches native radio.
+      this.select();
+    });
+  }
+
+  private syncSize(): void {
+    const labelBounds = this.labelText?.getBounds();
+    const labelWidth = labelBounds?.width ?? 0;
+    const labelHeight = labelBounds?.height ?? 0;
+    const totalWidth =
+      this.boxSidePx + (this.labelText ? this.labelGap + labelWidth : 0);
+    const totalHeight = Math.max(this.boxSidePx, labelHeight);
+    this.hitRect.setSize(totalWidth, totalHeight);
+    this.setSize(totalWidth, totalHeight);
+  }
+
+  private applyDisabledVisual(): void {
+    const targetAlpha = this.disabledState ? DISABLED_ALPHA : 1;
+    this.boxSprite.setAlpha(targetAlpha);
+    this.iconText.setAlpha(this.checkedState ? targetAlpha : 0);
+    if (this.labelText) this.labelText.setAlpha(targetAlpha);
+  }
+
+  private animateIcon(toChecked: boolean): void {
+    this.scene.tweens.killTweensOf(this.iconText);
+    const targetAlpha = toChecked
+      ? this.disabledState
+        ? DISABLED_ALPHA
+        : 1
+      : 0;
+    const targetScale = toChecked ? 1 : 0;
+    this.scene.tweens.add({
+      targets: this.iconText,
+      alpha: targetAlpha,
+      scaleX: targetScale,
+      scaleY: targetScale,
+      duration: toChecked
+        ? SELECT_TWEEN_DURATION_MS
+        : DESELECT_TWEEN_DURATION_MS,
+      ease: toChecked ? SELECT_TWEEN_EASE : DESELECT_TWEEN_EASE,
+    });
+  }
+
+  private getBoxTextureKey(): string {
+    return `radio_box_${this.colorInput}_${this.borderRadiusPx}_${this.boxSidePx}_${this.checkedState ? 'on' : 'off'}`;
+  }
+
+  private drawBoxTexture(scene: Scene, textureKey: string): void {
+    if (scene.textures.exists(textureKey)) return;
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
+    const textureSide = this.boxSidePx + padding * 2;
+
+    const graphics = scene.add.graphics();
+    const maxRadius = Math.floor(this.boxSidePx / 2);
+    const radius = Math.min(this.borderRadiusPx, maxRadius);
+
+    if (this.checkedState) {
+      graphics.fillStyle(this.colorFilled, 1);
+      graphics.fillRoundedRect(
+        padding,
+        padding,
+        this.boxSidePx,
+        this.boxSidePx,
+        radius
+      );
+    } else {
+      const half = BOX_BORDER_THICKNESS / 2;
+      graphics.lineStyle(BOX_BORDER_THICKNESS, this.colorFilled, 1);
+      graphics.strokeRoundedRect(
+        padding + half,
+        padding + half,
+        this.boxSidePx - BOX_BORDER_THICKNESS,
+        this.boxSidePx - BOX_BORDER_THICKNESS,
+        Math.max(0, radius - half)
+      );
+      // Subtle translucent fill — readable on any background.
+      graphics.fillStyle(this.colorFilled, Opacity.value('10'));
+      graphics.fillRoundedRect(
+        padding,
+        padding,
+        this.boxSidePx,
+        this.boxSidePx,
+        radius
+      );
+    }
+
+    graphics.generateTexture(textureKey, textureSide, textureSide);
+    graphics.destroy();
+  }
+
+  private regenerateBoxTexture(): void {
+    const textureKey = this.getBoxTextureKey();
+    this.drawBoxTexture(this.scene, textureKey);
+    this.boxSprite.setTexture(textureKey);
+  }
+}

--- a/packages/hudini/src/components/text-button/text-button.spec.ts
+++ b/packages/hudini/src/components/text-button/text-button.spec.ts
@@ -69,6 +69,41 @@ vi.mock('../text', () => {
 });
 
 // Mock phaser-wind with palette
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 40;
+    public height = 20;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    layout(): void {
+      /* noop */
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
 vi.mock('phaser-wind', () => ({
   Color: {
     rgb: vi.fn((color: string) => `rgb-${color}`),
@@ -247,6 +282,13 @@ vi.mock('phaser', () => {
     add(): this {
       return this;
     }
+    remove(): this {
+      return this;
+    }
+    addAt(): this {
+      return this;
+    }
+    list: unknown[] = [];
     scene: Scene;
   }
 

--- a/packages/hudini/src/components/text-button/text-button.ts
+++ b/packages/hudini/src/components/text-button/text-button.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable complexity */
+/* eslint-disable max-lines */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
 import { GameObjects, Scene } from 'phaser';
 import {
   Color,
@@ -19,6 +21,7 @@ import {
 } from '../../utils/button-style';
 import { getPWFromScene } from '../../utils/get-pw-from-scene';
 import { ContainerInteractive } from '../container-interactive';
+import { Stack } from '../stack';
 import { Text } from '../text';
 
 /**
@@ -67,6 +70,21 @@ export type TextButtonParams = {
    */
   variant?: ButtonVariant;
   /**
+   * Optional Font Awesome icon shown to the LEFT of the text.
+   * Renders with the same color/stroke rules as the text (variant-aware).
+   */
+  leftIcon?: IconKey;
+  /**
+   * Optional Font Awesome icon shown to the RIGHT of the text.
+   * Renders with the same color/stroke rules as the text (variant-aware).
+   */
+  rightIcon?: IconKey;
+  /**
+   * Gap between icon(s) and text in pixels. Defaults to a value proportional
+   * to the font size (roughly `fontSize * 0.35`), min 4px.
+   */
+  iconGap?: number;
+  /**
    * Callback function for click event.
    */
   onClick?: () => void;
@@ -88,6 +106,11 @@ const POINTER_DOWN_SCALE = 0.95;
  */
 const TEXTURE_ANTIALIAS_MARGIN = 1;
 
+/** Minimum gap between icon and text, in pixels. */
+const MIN_ICON_TEXT_GAP_PX = 4;
+/** Default icon-text gap as a fraction of the font size. */
+const ICON_TEXT_GAP_RATIO = 0.35;
+
 /**
  * A customizable text button component for Phaser, supporting auto-sizing,
  * design tokens, and interactive effects.
@@ -97,6 +120,12 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   public backgroundSprite!: GameObjects.Sprite;
   /** The text object of the button. */
   public buttonText!: GameObjects.Text;
+  /** Horizontal Stack composing (optional leftIcon) + text + (optional rightIcon). */
+  public contentStack!: Stack;
+  /** Left icon glyph, when `leftIcon` is set. */
+  public leftIconText: IconText | undefined;
+  /** Right icon glyph, when `rightIcon` is set. */
+  public rightIconText: IconText | undefined;
 
   private pw: PhaserWindPlugin<{}>;
   private fontSizePx!: number;
@@ -108,6 +137,9 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   private fontFamily!: string;
   private textValue!: string;
   private variant!: ButtonVariant;
+  private leftIconKey: IconKey | undefined;
+  private rightIconKey: IconKey | undefined;
+  private iconGap: number | undefined;
   /**
    * Creates a new TextButton instance.
    * @param params TextButtonParams
@@ -124,6 +156,9 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     borderRadius = 'md',
     padding = '4',
     variant = 'filled',
+    leftIcon,
+    rightIcon,
+    iconGap,
     onClick,
   }: TextButtonParams) {
     super({ scene, x, y });
@@ -132,6 +167,9 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     // Store values
     this.textValue = text;
     this.variant = variant;
+    this.leftIconKey = leftIcon;
+    this.rightIconKey = rightIcon;
+    this.iconGap = iconGap;
     this.fontSizePx =
       typeof fontSize === 'number'
         ? fontSize
@@ -161,7 +199,7 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
         : this.pw.font.family(font)
       : 'Fredoka';
 
-    this.createButtonText(scene);
+    this.createButtonContent(scene);
     this.createBackgroundSprite(scene);
     this.setupContainer();
     this.hitArea = this.backgroundSprite;
@@ -191,7 +229,8 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
       typeof fontSize === 'number'
         ? fontSize
         : this.pw.fontSize.px(fontSize ?? ('md' as FontSizeKey));
-    this.buttonText.setFontSize(this.fontSizePx);
+    // Icons also scale with fontSizePx, so rebuild the whole content.
+    this.rebuildContent();
     this.regenerateSprites();
     return this;
   }
@@ -219,6 +258,8 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   public setColor(color: ColorKey | string): this {
     this.colorInput = String(color);
     this.colorButton = Color.rgb(color as ColorKey);
+    // Text stroke + icon colors derive from `colorInput` — rebuild.
+    this.rebuildContent();
     this.regenerateSprites();
     return this;
   }
@@ -264,28 +305,53 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
 
   /**
    * Switch between `'filled'` and `'outline'` variants at runtime.
-   * Rebuilds the button text (stroke on/off) as well as the background sprite.
+   * Rebuilds both content (text + icons stroke/color) and the background.
    */
   public setVariant(variant: ButtonVariant): this {
     if (this.variant === variant) return this;
     this.variant = variant;
-    // Recreate the text so its stroke config reflects the new variant.
-    this.remove(this.buttonText, true);
-    this.createButtonText(this.scene);
-    this.addAt(this.buttonText, this.list.length);
+    this.rebuildContent();
     this.regenerateSprites();
     return this;
   }
 
   /**
-   * Creates the button text GameObject.
-   * @param scene Phaser scene.
+   * Sets (or removes) the left icon. Pass `undefined` to clear.
    */
-  private createButtonText(scene: Scene): void {
-    // In `outline`, the border itself does the visual work — the text sits on
-    // a transparent bg, so an extra stroke around it would look muddy. Keep
-    // it clean (no stroke) and let the text color carry the contrast.
+  public setLeftIcon(icon: IconKey | undefined): this {
+    this.leftIconKey = icon;
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /**
+   * Sets (or removes) the right icon. Pass `undefined` to clear.
+   */
+  public setRightIcon(icon: IconKey | undefined): this {
+    this.rightIconKey = icon;
+    this.rebuildContent();
+    this.regenerateSprites();
+    return this;
+  }
+
+  /**
+   * Creates the button's content: optional left icon + text + optional right
+   * icon, composed in a horizontal Stack. In `outline` mode, icons and text
+   * share the same colored appearance (no stroke); in `filled` mode both
+   * carry a darker outline stroke via `getButtonStrokeColor`.
+   */
+  private createButtonContent(scene: Scene): void {
     const isOutline = this.variant === 'outline';
+    const strokeThickness = isOutline ? 0 : BUTTON_STROKE_THICKNESS;
+    const strokeColor = isOutline
+      ? 'rgba(0,0,0,0)'
+      : getButtonStrokeColor(this.colorInput);
+    const glyphColor = isOutline
+      ? Color.rgb(this.colorInput as ColorKey)
+      : Color.rgb('white');
+
+    // Text
     this.buttonText = new Text({
       scene,
       x: 0,
@@ -293,17 +359,85 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
       text: this.textValue,
       size: this.fontSizePx,
       fontFamily: this.fontFamily,
-      strokeThickness: isOutline ? 0 : BUTTON_STROKE_THICKNESS,
-      strokeColor: isOutline ? 'rgba(0,0,0,0)' : getButtonStrokeColor(this.colorInput),
+      strokeThickness,
+      strokeColor,
     });
     // Preserve legacy behavior for `filled`: `textColor` on the constructor
     // was historically dead (only `setTextColor()` after construction applied
     // it). Outline needs the color for the border/text pairing to work, so
     // we only push it into the Text object in that mode.
-    if (this.variant === 'outline') {
+    if (isOutline) {
       this.buttonText.setColor(this.textColorValue);
     }
     this.buttonText.setOrigin(0.5, 0.5);
+
+    // Optional icons — same visual treatment as the text so the composition
+    // reads as one unified label.
+    this.leftIconText = this.leftIconKey
+      ? this.createIcon(scene, this.leftIconKey, glyphColor, strokeColor, strokeThickness)
+      : undefined;
+    this.rightIconText = this.rightIconKey
+      ? this.createIcon(scene, this.rightIconKey, glyphColor, strokeColor, strokeThickness)
+      : undefined;
+
+    // Compose in a horizontal Stack. Order: [leftIcon?, text, rightIcon?].
+    const children: GameObjects.GameObject[] = [];
+    if (this.leftIconText) children.push(this.leftIconText);
+    children.push(this.buttonText);
+    if (this.rightIconText) children.push(this.rightIconText);
+
+    const gap =
+      this.iconGap ??
+      Math.max(
+        MIN_ICON_TEXT_GAP_PX,
+        Math.round(this.fontSizePx * ICON_TEXT_GAP_RATIO)
+      );
+    this.contentStack = new Stack({
+      scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap,
+      children,
+    });
+  }
+
+  private createIcon(
+    scene: Scene,
+    icon: IconKey,
+    color: string,
+    strokeColor: string,
+    strokeThickness: number
+  ): IconText {
+    const iconText = new IconText({
+      scene,
+      x: 0,
+      y: 0,
+      icon,
+      size: this.fontSizePx,
+      style: {
+        color,
+        strokeThickness,
+        stroke: strokeColor,
+      },
+    });
+    iconText.setFontStyle('900');
+    iconText.setOrigin(0.5, 0.5);
+    scene.add.existing(iconText);
+    return iconText;
+  }
+
+  /**
+   * Tear down the current content stack and rebuild it. Used by setters that
+   * change how the content should be rendered (variant, color, font size,
+   * icons). Cheap enough to not worry about it — buttons aren't tweened on
+   * every frame.
+   */
+  private rebuildContent(): void {
+    this.remove(this.contentStack, true);
+    this.createButtonContent(this.scene);
+    this.add(this.contentStack);
   }
 
   /**
@@ -317,11 +451,14 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   }
 
   /**
-   * Regenerates the background and shadow textures based on current state.
+   * Regenerates the background sprite based on current state. Also relayouts
+   * the content Stack (icons + text) to reflect fresh text bounds.
    */
   private regenerateSprites(): void {
     // Update text bounds after text/font changes
     this.buttonText.setText(this.textValue);
+    // Re-layout the horizontal Stack so icons stay flush to the new text width.
+    this.contentStack.layout();
 
     // Regenerate textures
     const backgroundTexture = this.createBackgroundTexture(this.scene);
@@ -340,13 +477,14 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   }
 
   /**
-   * Calculates the button's width and height based on text and margin.
-   * @returns Object with width and height.
+   * Calculates the button's width and height from the horizontal content
+   * Stack (icons + text) plus the button's own padding on both axes.
    */
   private getButtonDimensions(): { width: number; height: number } {
-    const textBounds = this.buttonText.getBounds();
-    const width = textBounds.width + this.paddingPx * 2;
-    const height = textBounds.height + this.paddingPx * 2;
+    const contentWidth = this.contentStack.width;
+    const contentHeight = this.contentStack.height;
+    const width = contentWidth + this.paddingPx * 2;
+    const height = contentHeight + this.paddingPx * 2;
     return { width, height };
   }
 
@@ -406,10 +544,11 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
   }
 
   /**
-   * Adds the button's visual elements to the container.
+   * Adds the button's visual elements to the container. Order matters:
+   * background first (behind), then the icon+text content (in front).
    */
   private setupContainer(): void {
-    this.add([this.backgroundSprite, this.buttonText]);
+    this.add([this.backgroundSprite, this.contentStack]);
   }
 
   /**
@@ -443,7 +582,7 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
     // Click effects
     this.backgroundSprite.on('pointerdown', () => {
       this.scene.tweens.add({
-        targets: [this.backgroundSprite, this.buttonText],
+        targets: [this.backgroundSprite, this.contentStack],
         scaleX: POINTER_DOWN_SCALE,
         scaleY: POINTER_DOWN_SCALE,
         duration: durations.click,
@@ -453,7 +592,7 @@ export class TextButton extends ContainerInteractive<Phaser.GameObjects.Sprite> 
 
     this.backgroundSprite.on('pointerup', () => {
       this.scene.tweens.add({
-        targets: [this.backgroundSprite, this.buttonText],
+        targets: [this.backgroundSprite, this.contentStack],
         scaleX: 1,
         scaleY: 1,
         duration: durations.click,

--- a/packages/hudini/src/components/toggle/index.ts
+++ b/packages/hudini/src/components/toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './toggle';

--- a/packages/hudini/src/components/toggle/toggle.spec.ts
+++ b/packages/hudini/src/components/toggle/toggle.spec.ts
@@ -1,0 +1,389 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-disable max-lines-per-function */
+/* eslint-disable max-lines */
+/* eslint-disable sonarjs/no-identical-functions */
+import { Scene } from 'phaser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('font-awesome-for-phaser', () => {
+  class IconText {
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    setFontStyle(): this {
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+  }
+  return { IconText };
+});
+
+vi.mock('../stack', () => {
+  class MockStack {
+    public width = 50;
+    public height = 24;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_params: unknown) {}
+    layout(): void {
+      /* noop */
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  return { Stack: MockStack };
+});
+
+vi.mock('phaser-wind', () => ({
+  Color: {
+    rgb: vi.fn((color: string) => `rgb-${color}`),
+    hex: vi.fn(() => 0x22c55e),
+  },
+}));
+
+vi.mock('../../utils/get-pw-from-scene', () => ({
+  getPWFromScene: vi.fn(() => ({
+    fontSize: {
+      px: vi.fn((size: string) => {
+        const sizes = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+        return sizes[size as keyof typeof sizes] || 16;
+      }),
+    },
+    radius: {
+      px: vi.fn(() => 9999),
+    },
+  })),
+}));
+
+vi.mock('../text', () => {
+  class MockText {
+    private text: string;
+    // eslint-disable-next-line no-unused-vars
+    constructor(params: { text: string }) {
+      this.text = params.text;
+    }
+    setText(t: string): this {
+      this.text = t;
+      return this;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setColor(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+    getBounds(): { width: number; height: number } {
+      return { width: this.text.length * 10, height: 18 };
+    }
+  }
+  return { Text: MockText };
+});
+
+vi.mock('phaser', () => {
+  class MockSprite {
+    public width = 0;
+    public height = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _texture: string) {}
+    setOrigin(): this {
+      return this;
+    }
+    setTexture(): this {
+      return this;
+    }
+    setAlpha(): this {
+      return this;
+    }
+  }
+  class MockRectangle {
+    public width = 0;
+    public height = 0;
+    public listeners: Record<string, Array<() => void>> = {};
+    constructor(
+      _x: number,
+      _y: number,
+      w: number,
+      h: number,
+      // eslint-disable-next-line no-unused-vars
+      _c: number,
+      // eslint-disable-next-line no-unused-vars
+      _a: number
+    ) {
+      this.width = w;
+      this.height = h;
+    }
+    setOrigin(): this {
+      return this;
+    }
+    setInteractive(): this {
+      return this;
+    }
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+    on(evt: string, cb: () => void): this {
+      (this.listeners[evt] ||= []).push(cb);
+      return this;
+    }
+    emit(evt: string): this {
+      (this.listeners[evt] ?? []).forEach((cb) => cb());
+      return this;
+    }
+  }
+  class MockGraphics {
+    fillStyle(): this {
+      return this;
+    }
+    fillRoundedRect(): this {
+      return this;
+    }
+    generateTexture(): this {
+      return this;
+    }
+    destroy(): this {
+      return this;
+    }
+  }
+  class MockInnerContainer {
+    public width = 0;
+    public height = 0;
+    public x = 0;
+    // eslint-disable-next-line no-unused-vars
+    constructor(_x: number, _y: number, _children: unknown[]) {}
+    setSize(w: number, h: number): this {
+      this.width = w;
+      this.height = h;
+      return this;
+    }
+  }
+  class Container {
+    scene: Scene;
+    list: unknown[] = [];
+    // eslint-disable-next-line no-unused-vars
+    constructor(_scene: Scene, _x: number, _y: number) {
+      this.scene = _scene;
+    }
+    add(): this {
+      return this;
+    }
+    remove(): this {
+      return this;
+    }
+    addAt(): this {
+      return this;
+    }
+    setSize(): this {
+      return this;
+    }
+  }
+  class Scene {
+    tweens = {
+      add: vi.fn(),
+      killTweensOf: vi.fn(),
+    };
+    textures = {
+      exists: vi.fn(() => false),
+    };
+    add = {
+      existing: vi.fn(),
+      sprite: vi.fn(
+        (x: number, y: number, texture: string) => new MockSprite(x, y, texture)
+      ),
+      rectangle: vi.fn(
+        (
+          x: number,
+          y: number,
+          w: number,
+          h: number,
+          c: number,
+          a: number
+        ) => new MockRectangle(x, y, w, h, c, a)
+      ),
+      graphics: vi.fn(() => new MockGraphics()),
+      container: vi.fn(
+        (x: number, y: number, children: unknown[]) =>
+          new MockInnerContainer(x, y, children)
+      ),
+    };
+  }
+  const GameObjects = { Container };
+  return { GameObjects, Scene };
+});
+
+import { Toggle } from './toggle';
+
+describe('Toggle', () => {
+  it('should default to unchecked', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    expect(t.getValue()).toBe(false);
+    expect(t.isChecked()).toBe(false);
+  });
+
+  it('should honor the initial checked prop', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0, checked: true });
+    expect(t.getValue()).toBe(true);
+  });
+
+  it('should toggle', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    t.toggle();
+    expect(t.isChecked()).toBe(true);
+    t.toggle();
+    expect(t.isChecked()).toBe(false);
+  });
+
+  it('should fire onChange with the new value + name', () => {
+    const scene = new Scene();
+    const changes: Array<[boolean, string | undefined]> = [];
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      name: 'dark',
+      onChange: (v, n): void => {
+        changes.push([v, n]);
+      },
+    });
+    t.toggle();
+    t.toggle();
+    expect(changes).toEqual([
+      [true, 'dark'],
+      [false, 'dark'],
+    ]);
+  });
+
+  it('should NOT fire onChange when setChecked is called with the same value', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      checked: true,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    t.setChecked(true);
+    expect(calls).toBe(0);
+    t.setChecked(false);
+    expect(calls).toBe(1);
+  });
+
+  it('should ignore clicks when disabled', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      disabled: true,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    (t.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(calls).toBe(0);
+    expect(t.getValue()).toBe(false);
+  });
+
+  it('should ignore clicks when readOnly but still allow programmatic setChecked', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      readOnly: true,
+      onChange: (): void => {
+        calls++;
+      },
+    });
+    (t.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(calls).toBe(0);
+    t.setChecked(true);
+    expect(calls).toBe(1);
+  });
+
+  it('should support disable/enable shortcuts', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    t.disable();
+    expect(t.isDisabled()).toBe(true);
+    t.enable();
+    expect(t.isDisabled()).toBe(false);
+  });
+
+  it('should support setReadOnly / isReadOnly', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    t.setReadOnly(true);
+    expect(t.isReadOnly()).toBe(true);
+  });
+
+  it('should create both onIcon and offIcon by default', () => {
+    const scene = new Scene();
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    expect(t.onIconText).toBeDefined();
+    expect(t.offIconText).toBeDefined();
+  });
+
+  it('should skip an icon when explicitly set to null', () => {
+    const scene = new Scene();
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      onIcon: null,
+      offIcon: null,
+    });
+    expect(t.onIconText).toBeUndefined();
+    expect(t.offIconText).toBeUndefined();
+  });
+
+  it('should fire onClick even when the state does not change internally', () => {
+    const scene = new Scene();
+    let clicks = 0;
+    const t = new Toggle({
+      scene,
+      x: 0,
+      y: 0,
+      onClick: (): void => {
+        clicks++;
+      },
+    });
+    (t.hitRect as unknown as { emit: (e: string) => void }).emit('pointerdown');
+    expect(clicks).toBe(1);
+  });
+
+  it('should allow replacing the onChange callback', () => {
+    const scene = new Scene();
+    let calls = 0;
+    const t = new Toggle({ scene, x: 0, y: 0 });
+    t.onChange((): void => {
+      calls++;
+    });
+    t.toggle();
+    expect(calls).toBe(1);
+    t.onChange(undefined);
+    t.toggle();
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/hudini/src/components/toggle/toggle.ts
+++ b/packages/hudini/src/components/toggle/toggle.ts
@@ -1,0 +1,531 @@
+/* eslint-disable max-lines-per-function */
+/* eslint-disable complexity */
+/* eslint-disable max-lines */
+import { IconText, type IconKey } from 'font-awesome-for-phaser';
+import { GameObjects, Scene } from 'phaser';
+import {
+  Color,
+  PhaserWindPlugin,
+  type ColorKey,
+  type FontSizeKey,
+  type RadiusKey,
+} from 'phaser-wind';
+
+import { getPWFromScene } from '../../utils/get-pw-from-scene';
+import { ContainerInteractive } from '../container-interactive';
+import { Stack } from '../stack';
+import { Text } from '../text';
+
+/** Parameters for creating a {@link Toggle}. */
+export type ToggleParams = {
+  /** Phaser scene where the toggle will be added. */
+  scene: Scene;
+  /** X position (center of the whole content — switch + label). */
+  x: number;
+  /** Y position (center of the whole content). */
+  y: number;
+  /** Initial checked state. Default `false`. */
+  checked?: boolean;
+  /** Muted + non-interactive when `true`. Default `false`. */
+  disabled?: boolean;
+  /** Visually normal but ignores clicks when `true`. Default `false`. */
+  readOnly?: boolean;
+  /** Optional metadata passed back as the 2nd arg of `onChange`. */
+  name?: string;
+  /** Optional text label to the right of the switch. Clicking it toggles too. */
+  label?: string;
+  /**
+   * Icon inside the handle when checked. Default `'check'`. Pass `null` to
+   * render no icon in the on state.
+   */
+  onIcon?: IconKey | null;
+  /**
+   * Icon inside the handle when unchecked. Default `'xmark'`. Pass `null` to
+   * render no icon in the off state.
+   */
+  offIcon?: IconKey | null;
+  /** Icon color (default `'slate-700'` for contrast on a white handle). */
+  iconColor?: ColorKey | string;
+  /** Track color when checked. Default `'green-500'`. */
+  color?: ColorKey | string;
+  /** Track color when unchecked. Default `'slate-400'`. */
+  offColor?: ColorKey | string;
+  /** Handle (circle) color. Default `'white'`. */
+  handleColor?: ColorKey | string;
+  /** Label text color. Default `'slate-800'`. */
+  labelColor?: ColorKey | string;
+  /**
+   * Reference size. Drives label font size and switch proportions. Default
+   * `'base'` (16px).
+   */
+  size?: FontSizeKey | number;
+  /**
+   * Track border radius. Default `'full'` — pill shape, which matches
+   * daisyUI's toggle.
+   */
+  borderRadius?: RadiusKey | number;
+  /** Gap between switch and label in pixels. Default 8. */
+  labelGap?: number;
+  /** Fires whenever the checked state changes. */
+  onChange?: (checked: boolean, name?: string) => void;
+  /** Fires on any click, regardless of whether the state changed. */
+  onClick?: () => void;
+};
+
+const DEFAULT_SIZE_KEY: FontSizeKey = 'base';
+const DEFAULT_ON_ICON: IconKey = 'check';
+const DEFAULT_OFF_ICON: IconKey = 'xmark';
+
+// Sizing constants (relative to `size`).
+const HANDLE_PADDING_INSIDE_TRACK = 2;
+const TRACK_PADDING_AROUND_HANDLE = 2;
+const TRACK_ASPECT_RATIO = 2; // width = height * ratio
+
+const TEXTURE_ANTIALIAS_MARGIN = 1;
+const DEFAULT_LABEL_GAP = 8;
+const DISABLED_ALPHA = 0.4;
+
+// Tween timings — a hair slower than Checkbox for a physical "switch" feel.
+const SLIDE_DURATION_MS = 180;
+const SLIDE_EASE = 'Back.easeOut';
+const ICON_FADE_DURATION_MS = 150;
+
+/**
+ * Toggle — a daisyUI-style switch. Same API contract as {@link Checkbox},
+ * different look and feel: a pill-shaped track with a sliding handle that
+ * can carry an icon per state (with a cross-fade when the icons differ).
+ *
+ * @example
+ * new Toggle({
+ *   scene, x, y,
+ *   checked: true,
+ *   label: 'Sound',
+ *   color: 'green-500',
+ * });
+ *
+ * @example
+ * // Themed icons per state (e.g., dark-mode switcher)
+ * new Toggle({
+ *   scene, x, y,
+ *   label: 'Dark mode',
+ *   onIcon: 'moon',
+ *   offIcon: 'sun',
+ *   color: 'indigo-600',
+ *   offColor: 'yellow-400',
+ * });
+ */
+export class Toggle extends ContainerInteractive<Phaser.GameObjects.Rectangle> {
+  /** The track (pill background) sprite. */
+  public trackSprite!: GameObjects.Sprite;
+  /** The handle (circle) sprite. */
+  public handleSprite!: GameObjects.Sprite;
+  /** Container that holds handle + icons and slides between the two positions. */
+  public handleGroup!: GameObjects.Container;
+  /** Icon rendered when checked (invisible when unchecked). */
+  public onIconText: IconText | undefined;
+  /** Icon rendered when unchecked (invisible when checked). */
+  public offIconText: IconText | undefined;
+  /** Optional label text. */
+  public labelText: GameObjects.Text | undefined;
+  /** Invisible hit rect covering track + label. */
+  public hitRect!: GameObjects.Rectangle;
+
+  private pw: PhaserWindPlugin<{}>;
+  private checkedState: boolean;
+  private disabledState: boolean;
+  private readOnlyState: boolean;
+  private sizePx!: number;
+  private trackWidthPx!: number;
+  private trackHeightPx!: number;
+  private handleDiameterPx!: number;
+  private handleXOn!: number;
+  private handleXOff!: number;
+  private borderRadiusPx!: number;
+  private trackOnColorHex!: number;
+  private trackOffColorHex!: number;
+  private handleColorHex!: number;
+  private iconColorValue!: string;
+  private labelColorValue!: string;
+  private onIconKey: IconKey | undefined;
+  private offIconKey: IconKey | undefined;
+  private labelValue: string | undefined;
+  private labelGap: number;
+  private onChangeCb: ((checked: boolean, name?: string) => void) | undefined;
+  private onClickCb: (() => void) | undefined;
+
+  constructor({
+    scene,
+    x,
+    y,
+    checked = false,
+    disabled = false,
+    readOnly = false,
+    name,
+    label,
+    onIcon,
+    offIcon,
+    iconColor = 'slate-700',
+    color = 'green-500',
+    offColor = 'slate-400',
+    handleColor = 'white',
+    labelColor = 'slate-800',
+    size = DEFAULT_SIZE_KEY,
+    borderRadius = 'full',
+    labelGap = DEFAULT_LABEL_GAP,
+    onChange,
+    onClick,
+  }: ToggleParams) {
+    super({ scene, x, y });
+    this.pw = getPWFromScene(scene);
+
+    this.checkedState = checked;
+    this.disabledState = disabled;
+    this.readOnlyState = readOnly;
+    if (name !== undefined) this.name = name;
+    this.labelValue = label;
+    // Default on/off icons; `null` explicitly disables one.
+    this.onIconKey =
+      onIcon === null ? undefined : onIcon ?? DEFAULT_ON_ICON;
+    this.offIconKey =
+      offIcon === null ? undefined : offIcon ?? DEFAULT_OFF_ICON;
+    this.labelGap = labelGap;
+    this.onChangeCb = onChange;
+    this.onClickCb = onClick;
+
+    this.sizePx =
+      typeof size === 'number'
+        ? size
+        : this.pw.fontSize.px(size ?? DEFAULT_SIZE_KEY);
+
+    this.handleDiameterPx = this.sizePx + HANDLE_PADDING_INSIDE_TRACK * 2;
+    this.trackHeightPx =
+      this.handleDiameterPx + TRACK_PADDING_AROUND_HANDLE * 2;
+    this.trackWidthPx = this.trackHeightPx * TRACK_ASPECT_RATIO;
+    this.handleXOff =
+      -this.trackWidthPx / 2 +
+      this.handleDiameterPx / 2 +
+      TRACK_PADDING_AROUND_HANDLE;
+    this.handleXOn = -this.handleXOff;
+
+    this.borderRadiusPx =
+      typeof borderRadius === 'number'
+        ? borderRadius
+        : this.pw.radius.px(borderRadius ?? ('full' as RadiusKey));
+
+    this.trackOnColorHex = Color.hex(color as ColorKey);
+    this.trackOffColorHex = Color.hex(offColor as ColorKey);
+    this.handleColorHex = Color.hex(handleColor as ColorKey);
+    this.iconColorValue = Color.rgb(iconColor as ColorKey);
+    this.labelColorValue = Color.rgb(labelColor as ColorKey);
+
+    this.createTrack(scene);
+    this.createHandle(scene);
+    this.createIcons(scene);
+    this.createLabel(scene);
+    this.createHitRect(scene);
+    this.setupContainer();
+    this.hitArea = this.hitRect;
+
+    this.applyInitialState();
+    this.applyDisabledVisual();
+    this.setupInteractivity();
+    this.syncSize();
+  }
+
+  // -------- public API --------
+
+  public toggle(): this {
+    return this.setChecked(!this.checkedState);
+  }
+
+  public setChecked(checked: boolean): this {
+    if (this.checkedState === checked) return this;
+    this.checkedState = checked;
+    this.animateToState(checked);
+    this.onChangeCb?.(checked, this.name === '' ? undefined : this.name);
+    return this;
+  }
+
+  public isChecked(): boolean {
+    return this.checkedState;
+  }
+
+  public getValue(): boolean {
+    return this.checkedState;
+  }
+
+  public setDisabled(disabled: boolean): this {
+    if (this.disabledState === disabled) return this;
+    this.disabledState = disabled;
+    this.applyDisabledVisual();
+    return this;
+  }
+
+  public disable(): this {
+    return this.setDisabled(true);
+  }
+
+  public enable(): this {
+    return this.setDisabled(false);
+  }
+
+  public isDisabled(): boolean {
+    return this.disabledState;
+  }
+
+  public setReadOnly(readOnly: boolean): this {
+    this.readOnlyState = readOnly;
+    return this;
+  }
+
+  public isReadOnly(): boolean {
+    return this.readOnlyState;
+  }
+
+  public onChange(
+    cb: ((checked: boolean, name?: string) => void) | undefined
+  ): this {
+    this.onChangeCb = cb;
+    return this;
+  }
+
+  public onClick(cb: (() => void) | undefined): this {
+    this.onClickCb = cb;
+    return this;
+  }
+
+  // -------- private --------
+
+  private createTrack(scene: Scene): void {
+    // Generate both textures upfront so switching between them is instant.
+    this.drawTrackTexture(scene, this.trackTextureKey(true), this.trackOnColorHex);
+    this.drawTrackTexture(scene, this.trackTextureKey(false), this.trackOffColorHex);
+    const initialKey = this.trackTextureKey(this.checkedState);
+    this.trackSprite = scene.add.sprite(0, 0, initialKey);
+    this.trackSprite.setOrigin(0.5, 0.5);
+  }
+
+  private createHandle(scene: Scene): void {
+    const handleKey = `toggle_handle_${this.handleColorHex}_${this.handleDiameterPx}`;
+    this.drawHandleTexture(scene, handleKey);
+    this.handleSprite = scene.add.sprite(0, 0, handleKey);
+    this.handleSprite.setOrigin(0.5, 0.5);
+  }
+
+  private createIcons(scene: Scene): void {
+    if (this.onIconKey) {
+      this.onIconText = new IconText({
+        scene,
+        x: 0,
+        y: 0,
+        icon: this.onIconKey,
+        size: this.sizePx,
+        style: { color: this.iconColorValue },
+      });
+      this.onIconText.setFontStyle('900');
+      this.onIconText.setOrigin(0.5, 0.5);
+      scene.add.existing(this.onIconText);
+    }
+    if (this.offIconKey) {
+      this.offIconText = new IconText({
+        scene,
+        x: 0,
+        y: 0,
+        icon: this.offIconKey,
+        size: this.sizePx,
+        style: { color: this.iconColorValue },
+      });
+      this.offIconText.setFontStyle('900');
+      this.offIconText.setOrigin(0.5, 0.5);
+      scene.add.existing(this.offIconText);
+    }
+  }
+
+  private createLabel(scene: Scene): void {
+    if (this.labelValue === undefined || this.labelValue === '') return;
+    this.labelText = new Text({
+      scene,
+      x: 0,
+      y: 0,
+      text: this.labelValue,
+      size: this.sizePx,
+      fontFamily: 'Fredoka',
+      strokeThickness: 0,
+      strokeColor: 'rgba(0,0,0,0)',
+    });
+    this.labelText.setColor(this.labelColorValue);
+    this.labelText.setOrigin(0.5, 0.5);
+  }
+
+  private createHitRect(scene: Scene): void {
+    this.hitRect = scene.add.rectangle(
+      0,
+      0,
+      this.trackWidthPx,
+      this.trackHeightPx,
+      0x000000,
+      0
+    );
+    this.hitRect.setOrigin(0.5, 0.5);
+  }
+
+  private setupContainer(): void {
+    // The handle group: handle sprite + both icons stacked at the same
+    // position. We translate this group between on/off X.
+    const groupChildren: GameObjects.GameObject[] = [this.handleSprite];
+    if (this.onIconText) groupChildren.push(this.onIconText);
+    if (this.offIconText) groupChildren.push(this.offIconText);
+    this.handleGroup = this.scene.add.container(0, 0, groupChildren);
+
+    // Switch container: track + handle group.
+    const switchContainer = this.scene.add.container(0, 0, [
+      this.trackSprite,
+      this.handleGroup,
+    ]);
+    switchContainer.setSize(this.trackWidthPx, this.trackHeightPx);
+
+    // Outer: hit rect + horizontal Stack (switch + optional label).
+    const stackChildren: GameObjects.GameObject[] = [switchContainer];
+    if (this.labelText) stackChildren.push(this.labelText);
+    const contentStack = new Stack({
+      scene: this.scene,
+      x: 0,
+      y: 0,
+      direction: 'row',
+      align: 'center',
+      gap: this.labelGap,
+      children: stackChildren,
+    });
+
+    this.add([this.hitRect, contentStack]);
+  }
+
+  private setupInteractivity(): void {
+    this.hitRect.setInteractive({ useHandCursor: true });
+    this.hitRect.on('pointerdown', () => {
+      if (this.disabledState || this.readOnlyState) return;
+      this.onClickCb?.();
+      this.toggle();
+    });
+  }
+
+  private syncSize(): void {
+    const labelBounds = this.labelText?.getBounds();
+    const labelWidth = labelBounds?.width ?? 0;
+    const labelHeight = labelBounds?.height ?? 0;
+    const totalWidth =
+      this.trackWidthPx +
+      (this.labelText ? this.labelGap + labelWidth : 0);
+    const totalHeight = Math.max(this.trackHeightPx, labelHeight);
+    this.hitRect.setSize(totalWidth, totalHeight);
+    this.setSize(totalWidth, totalHeight);
+  }
+
+  private applyInitialState(): void {
+    // Position the handle at the correct end and set icon visibility.
+    this.handleGroup.x = this.checkedState ? this.handleXOn : this.handleXOff;
+    if (this.onIconText) this.onIconText.setAlpha(this.checkedState ? 1 : 0);
+    if (this.offIconText) this.offIconText.setAlpha(this.checkedState ? 0 : 1);
+  }
+
+  private applyDisabledVisual(): void {
+    const targetAlpha = this.disabledState ? DISABLED_ALPHA : 1;
+    this.trackSprite.setAlpha(targetAlpha);
+    this.handleSprite.setAlpha(targetAlpha);
+    if (this.onIconText && this.checkedState) {
+      this.onIconText.setAlpha(targetAlpha);
+    }
+    if (this.offIconText && !this.checkedState) {
+      this.offIconText.setAlpha(targetAlpha);
+    }
+    if (this.labelText) this.labelText.setAlpha(targetAlpha);
+  }
+
+  private animateToState(checked: boolean): void {
+    // Swap the track texture instantly (color change).
+    this.trackSprite.setTexture(this.trackTextureKey(checked));
+
+    // Slide the handle.
+    this.scene.tweens.killTweensOf(this.handleGroup);
+    this.scene.tweens.add({
+      targets: this.handleGroup,
+      x: checked ? this.handleXOn : this.handleXOff,
+      duration: SLIDE_DURATION_MS,
+      ease: SLIDE_EASE,
+    });
+
+    // Cross-fade icons if they differ. When only one is set, the other side
+    // fades in/out from 0.
+    const iconTargetAlpha = this.disabledState ? DISABLED_ALPHA : 1;
+    if (this.onIconText) {
+      this.scene.tweens.killTweensOf(this.onIconText);
+      this.scene.tweens.add({
+        targets: this.onIconText,
+        alpha: checked ? iconTargetAlpha : 0,
+        duration: ICON_FADE_DURATION_MS,
+        ease: 'Sine.easeInOut',
+      });
+    }
+    if (this.offIconText) {
+      this.scene.tweens.killTweensOf(this.offIconText);
+      this.scene.tweens.add({
+        targets: this.offIconText,
+        alpha: checked ? 0 : iconTargetAlpha,
+        duration: ICON_FADE_DURATION_MS,
+        ease: 'Sine.easeInOut',
+      });
+    }
+  }
+
+  private trackTextureKey(on: boolean): string {
+    const colorHex = on ? this.trackOnColorHex : this.trackOffColorHex;
+    return `toggle_track_${colorHex}_${this.borderRadiusPx}_${this.trackWidthPx}_${this.trackHeightPx}`;
+  }
+
+  private drawTrackTexture(
+    scene: Scene,
+    textureKey: string,
+    colorHex: number
+  ): void {
+    if (scene.textures.exists(textureKey)) return;
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
+    const textureWidth = this.trackWidthPx + padding * 2;
+    const textureHeight = this.trackHeightPx + padding * 2;
+
+    const graphics = scene.add.graphics();
+    const maxRadius = Math.floor(this.trackHeightPx / 2);
+    const radius = Math.min(this.borderRadiusPx, maxRadius);
+
+    graphics.fillStyle(colorHex, 1);
+    graphics.fillRoundedRect(
+      padding,
+      padding,
+      this.trackWidthPx,
+      this.trackHeightPx,
+      radius
+    );
+
+    graphics.generateTexture(textureKey, textureWidth, textureHeight);
+    graphics.destroy();
+  }
+
+  private drawHandleTexture(scene: Scene, textureKey: string): void {
+    if (scene.textures.exists(textureKey)) return;
+    const padding = TEXTURE_ANTIALIAS_MARGIN;
+    const textureSide = this.handleDiameterPx + padding * 2;
+
+    const graphics = scene.add.graphics();
+    graphics.fillStyle(this.handleColorHex, 1);
+    // Full circle via radius = diameter/2.
+    graphics.fillRoundedRect(
+      padding,
+      padding,
+      this.handleDiameterPx,
+      this.handleDiameterPx,
+      this.handleDiameterPx / 2
+    );
+
+    graphics.generateTexture(textureKey, textureSide, textureSide);
+    graphics.destroy();
+  }
+}

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -48,25 +48,25 @@ const getUrl = (path: string) => {
       .sidebar-collapsed {
         width: 4rem !important;
       }
-      
+
       .sidebar-collapsed .sidebar-content {
         opacity: 0;
         transform: translateX(-100%);
         pointer-events: none;
       }
-      
+
       .sidebar-collapsed .sidebar-toggle {
         transform: rotate(180deg);
       }
-      
+
       .sidebar-content {
         transition: all 0.3s ease-in-out;
       }
-      
+
       .sidebar-toggle {
         transition: transform 0.3s ease-in-out;
       }
-      
+
       .sidebar {
         transition: width 0.3s ease-in-out;
       }
@@ -75,27 +75,27 @@ const getUrl = (path: string) => {
       .category-collapsed .category-links {
         display: none;
       }
-      
+
       .category-toggle {
         cursor: pointer;
         user-select: none;
         transition: all 0.2s ease-in-out;
       }
-      
+
       .category-toggle:hover {
         background-color: #f3f4f6;
       }
-      
+
       .category-toggle-icon {
         transition: transform 0.2s ease-in-out;
         display: inline-block;
         margin-left: 0.5rem;
       }
-      
+
       .category-collapsed .category-toggle-icon {
         transform: rotate(-90deg);
       }
-      
+
       .category-links {
         transition: all 0.2s ease-in-out;
       }
@@ -116,7 +116,7 @@ const getUrl = (path: string) => {
             </svg>
           </button>
         </div>
-        
+
         <nav class="sidebar-content p-4 space-y-2 overflow-y-auto flex-1">
           <!-- Main Navigation -->
           <div class="mb-4">
@@ -266,7 +266,7 @@ const getUrl = (path: string) => {
           <h1 class="text-2xl font-bold text-gray-900">{title}</h1>
           {description && <p class="text-gray-600 mt-1">{description}</p>}
         </div>
-        
+
         <div class="p-6">
           <slot />
         </div>
@@ -278,22 +278,22 @@ const getUrl = (path: string) => {
         const sidebar = document.getElementById('sidebar');
         const toggleButton = document.getElementById('sidebar-toggle');
         const titleButton = document.getElementById('sidebar-title');
-        
+
         // Função para alternar o estado da sidebar
         function toggleSidebar() {
           sidebar.classList.toggle('sidebar-collapsed');
-          
+
           // Salvar estado no localStorage
           const isNowCollapsed = sidebar.classList.contains('sidebar-collapsed');
           localStorage.setItem('sidebar-collapsed', isNowCollapsed.toString());
         }
-        
+
         // Verificar se há estado salvo no localStorage
         const isCollapsed = localStorage.getItem('sidebar-collapsed') === 'true';
         if (isCollapsed) {
           sidebar.classList.add('sidebar-collapsed');
         }
-        
+
         // Event listeners para sidebar
         toggleButton.addEventListener('click', toggleSidebar);
         titleButton.addEventListener('click', toggleSidebar);
@@ -302,7 +302,7 @@ const getUrl = (path: string) => {
         function toggleCategory(categoryName) {
           const categoryDiv = document.querySelector(`[data-category="${categoryName}"]`).parentElement;
           const isCollapsed = categoryDiv.classList.contains('category-collapsed');
-          
+
           if (isCollapsed) {
             categoryDiv.classList.remove('category-collapsed');
             localStorage.setItem(`category-${categoryName}-collapsed`, 'false');
@@ -315,13 +315,13 @@ const getUrl = (path: string) => {
         // Adicionar event listeners para todos os toggles de categoria
         document.querySelectorAll('.category-toggle').forEach(toggle => {
           const categoryName = toggle.getAttribute('data-category');
-          
+
           // Verificar estado salvo no localStorage
           const isCollapsed = localStorage.getItem(`category-${categoryName}-collapsed`) === 'true';
           if (isCollapsed) {
             toggle.parentElement.classList.add('category-collapsed');
           }
-          
+
           // Adicionar event listener
           toggle.addEventListener('click', () => toggleCategory(categoryName));
         });

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -148,6 +148,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/icon-button')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 🎯 Icon Button
               </a>
+              <a href={getUrl('/hudini/alert')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                🚨 Alert
+              </a>
               <a href={getUrl('/hudini/badge')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 🏷️ Badge
               </a>

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -157,6 +157,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/checkbox')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 ☑️ Checkbox
               </a>
+              <a href={getUrl('/hudini/toggle')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                🎚️ Toggle
+              </a>
               <a href={getUrl('/hudini/circular-progress')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 ⭕ Circular Progress
               </a>

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -154,6 +154,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/badge')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 🏷️ Badge
               </a>
+              <a href={getUrl('/hudini/checkbox')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                ☑️ Checkbox
+              </a>
               <a href={getUrl('/hudini/circular-progress')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 ⭕ Circular Progress
               </a>

--- a/packages/showcase/src/layouts/Layout.astro
+++ b/packages/showcase/src/layouts/Layout.astro
@@ -160,6 +160,9 @@ const getUrl = (path: string) => {
               <a href={getUrl('/hudini/toggle')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 🎚️ Toggle
               </a>
+              <a href={getUrl('/hudini/radio')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
+                🔘 Radio
+              </a>
               <a href={getUrl('/hudini/circular-progress')} class="block px-4 py-3 text-sm font-medium text-gray-700 rounded-lg transition-colors duration-200 hover:bg-gray-100 hover:text-gray-900">
                 ⭕ Circular Progress
               </a>

--- a/packages/showcase/src/pages/hudini/alert.astro
+++ b/packages/showcase/src/pages/hudini/alert.astro
@@ -1,0 +1,247 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Alert Component" description="Static notification banner with semantic variants (success / error / warning / info / neutral), optional icons and click handler — the content half of a daisyUI-style toast.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Alert Component</h2>
+      <p class="text-gray-600 mb-4">
+        A static (or optionally clickable) notification banner. Same visual language as a filled TextButton — colored fill, outlined text/icon — but without hover/click animations. Semantic variants come with sensible default colors and icons (daisyUI parity).
+      </p>
+      <p class="text-gray-600 mb-4">
+        Alert is intentionally content-only. For auto-dismiss / timing / entry animation, wrap it in a <code class="bg-gray-100 px-1 rounded">Toast</code> (separate component, later).
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>🎨 <strong>Semantic variants</strong>: <code>success</code>, <code>error</code>, <code>warning</code>, <code>info</code>, <code>neutral</code></li>
+          <li>🎯 <strong>Default icon per variant</strong>: check for success, X for error, etc — omit or override at will</li>
+          <li>🖼️ <strong>Left + right icons</strong>: same API as TextButton (leftIcon / rightIcon)</li>
+          <li>🖱️ <strong>Optional onClick</strong>: cursor becomes pointer, fires callback (great for "close" affordance)</li>
+          <li>🧱 <strong>Composes</strong>: sizes itself so Row/Column/Stack measures it correctly</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">text</code> - Message shown in the alert</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">variant</code> - <code>'info'</code> (default), <code>'success'</code>, <code>'error'</code>, <code>'warning'</code>, <code>'neutral'</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">color</code> - Override the variant's background color</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">textColor</code> - Text/icon color (default <code>'white'</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">leftIcon</code> - Font Awesome icon. Omit to use the variant default; pass <code>null</code> to explicitly disable it</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">rightIcon</code> - Optional Font Awesome icon on the right (e.g. <code>'xmark'</code> for a "close" hint)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">fontSize</code>, <code class="bg-gray-200 px-2 py-1 rounded">font</code>, <code class="bg-gray-200 px-2 py-1 rounded">padding</code>, <code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code> - Sizing/tokens</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onClick</code> - Optional click handler; when set the alert becomes interactive</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={640} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Alert,
+} from 'hudini';
+
+const theme = createTheme({});
+type Theme = typeof theme;
+
+class AlertDemoScene extends Phaser.Scene {
+    create(): void {
+        const hudini = withHudini<Theme>(this);
+        const { pw } = hudini;
+
+        // 1. Semantic variants — default color + icon per variant
+        new Alert({
+            scene: this, x: 400, y: 100,
+            variant: 'success',
+            text: 'Player saved!',
+        });
+
+        // 2. Override the variant's icon or color
+        new Alert({
+            scene: this, x: 400, y: 200,
+            variant: 'warning',
+            text: 'Low health',
+            leftIcon: 'heart-crack',   // override the default
+            rightIcon: 'xmark',         // "close" hint
+        });
+
+        // 3. Clickable
+        const alert = new Alert({
+            scene: this, x: 400, y: 300,
+            variant: 'error',
+            text: 'Tap to dismiss',
+            rightIcon: 'xmark',
+            onClick: () => alert.destroy(),
+        });
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Alert,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class AlertDemoScene extends Phaser.Scene {
+    constructor() {
+      super('alert-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(300));
+
+      const centerX = this.cameras.main.centerX;
+
+      // Header
+      this.add
+        .text(centerX, 30, 'Alert Component', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Section 1: variants with default icons ---
+      this.add
+        .text(centerX, 75, 'Semantic variants (default color + icon)', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const variants: Array<{ v: 'success' | 'error' | 'warning' | 'info' | 'neutral'; text: string }> = [
+        { v: 'success', text: 'Player saved!' },
+        { v: 'error', text: 'Connection lost' },
+        { v: 'warning', text: 'Low health' },
+        { v: 'info', text: 'New quest available' },
+        { v: 'neutral', text: 'Tutorial available' },
+      ];
+
+      variants.forEach((cfg, i) => {
+        const alert = new Alert({
+          scene: this,
+          x: centerX,
+          y: 120 + i * 55,
+          variant: cfg.v,
+          text: cfg.text,
+        });
+        this.add.existing(alert);
+      });
+
+      // --- Section 2: overrides / clickable ---
+      this.add
+        .text(centerX, 415, 'Icon overrides + clickable', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // Custom icon override
+      const customIcon = new Alert({
+        scene: this,
+        x: centerX,
+        y: 460,
+        variant: 'warning',
+        text: 'Health critical',
+        leftIcon: 'heart-crack',
+      });
+      this.add.existing(customIcon);
+
+      // Right icon (close hint) + click to dismiss
+      const dismissable = new Alert({
+        scene: this,
+        x: centerX,
+        y: 515,
+        variant: 'error',
+        text: 'Tap to dismiss',
+        rightIcon: 'xmark',
+        onClick: () => dismissable.destroy(),
+      });
+      this.add.existing(dismissable);
+
+      // Custom color (bypasses semantic variant color)
+      const custom = new Alert({
+        scene: this,
+        x: centerX,
+        y: 570,
+        variant: 'neutral',
+        color: 'purple-600',
+        text: 'Achievement unlocked',
+        leftIcon: 'trophy',
+      });
+      this.add.existing(custom);
+
+      // Footer
+      this.add
+        .text(centerX, 615, 'Wrap in a Toast (upcoming) for auto-dismiss + animation.', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0.5, 0.5);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [AlertDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-alert-demo'] = game;
+      });
+    }
+  });
+</script>

--- a/packages/showcase/src/pages/hudini/checkbox.astro
+++ b/packages/showcase/src/pages/hudini/checkbox.astro
@@ -1,0 +1,341 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Checkbox Component" description="Uncontrolled toggleable form control with custom icon, disabled/readOnly states, and a pop animation on state change.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Checkbox Component</h2>
+      <p class="text-gray-600 mb-4">
+        A toggleable form control. The Checkbox owns its own state (uncontrolled): read it back via <code class="bg-gray-100 px-1 rounded">getValue()</code> / <code class="bg-gray-100 px-1 rounded">isChecked()</code>, mutate it via <code class="bg-gray-100 px-1 rounded">toggle()</code> / <code class="bg-gray-100 px-1 rounded">setChecked(v)</code>, observe changes via the <code class="bg-gray-100 px-1 rounded">onChange</code> callback.
+      </p>
+      <p class="text-gray-600 mb-4">
+        For persistent named state, wire it up with <code class="bg-gray-100 px-1 rounded">phaser-hooks</code>' <code class="bg-gray-100 px-1 rounded">withLocalState</code> on the outside — the Checkbox stays decoupled from any store.
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>💚 <strong>Custom icon</strong>: default <code>check</code>, use any Font Awesome key (<code>heart</code>, <code>star</code>, <code>thumbs-up</code>, ...)</li>
+          <li>🎨 <strong>Custom colors</strong>: box color + icon color independently</li>
+          <li>🏷️ <strong>Optional label</strong>: clicking the label toggles too (HTML-label behavior)</li>
+          <li>🚫 <strong>Disabled + readOnly</strong>: separate states — disabled mutes the visual, readOnly only blocks clicks</li>
+          <li>✨ <strong>Pop animation</strong>: icon scales + fades in on check, out on uncheck (Back.easeOut)</li>
+          <li>📋 <strong>Form-ready</strong>: <code>name</code> + <code>getValue()</code> for building a Form later — no runtime dep on any state store</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">checked</code> - Initial state (default <code>false</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">label</code> - Optional text label to the right of the box</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">icon</code> - Font Awesome icon shown when checked (default <code>check</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">iconColor</code> - Color of the icon (default <code>white</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">color</code> - Box fill / border color (default <code>blue-500</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">labelColor</code>, <code class="bg-gray-200 px-2 py-1 rounded">size</code>, <code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code>, <code class="bg-gray-200 px-2 py-1 rounded">labelGap</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">disabled</code>, <code class="bg-gray-200 px-2 py-1 rounded">readOnly</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">name</code> - Form field name, passed as the second arg of <code>onChange</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onChange</code> - <code>(checked, name?) =&gt; void</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onClick</code> - Fires on any click, even if the state does not change</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Methods -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Methods</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">toggle()</code> / <code class="bg-gray-200 px-2 py-1 rounded">setChecked(v)</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">isChecked()</code> / <code class="bg-gray-200 px-2 py-1 rounded">getValue()</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">disable()</code> / <code class="bg-gray-200 px-2 py-1 rounded">enable()</code> / <code class="bg-gray-200 px-2 py-1 rounded">setDisabled(v)</code> / <code class="bg-gray-200 px-2 py-1 rounded">isDisabled()</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">setReadOnly(v)</code> / <code class="bg-gray-200 px-2 py-1 rounded">isReadOnly()</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onChange(cb)</code> / <code class="bg-gray-200 px-2 py-1 rounded">onClick(cb)</code> - Replace the handlers post-construction</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={620} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Checkbox,
+} from 'hudini';
+
+class SettingsScene extends Phaser.Scene {
+    create(): void {
+        // 1. Basic checkbox with a label
+        const sound = new Checkbox({
+            scene: this, x: 100, y: 100,
+            label: 'Enable sound',
+            checked: true,
+            name: 'sound',
+            onChange: (v, name) => console.log(name, v),
+        });
+
+        // 2. Custom icon (a heart for "favorite")
+        const favorite = new Checkbox({
+            scene: this, x: 100, y: 160,
+            label: 'Favorite',
+            icon: 'heart',
+            color: 'red-500',
+        });
+
+        // 3. Collect values later (mini form)
+        const submit = () => {
+            const payload = {
+                sound: sound.getValue(),
+                favorite: favorite.getValue(),
+            };
+            console.log('form:', payload);
+        };
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Checkbox,
+    TextButton,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class CheckboxDemoScene extends Phaser.Scene {
+    constructor() {
+      super('checkbox-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(200));
+
+      const centerX = this.cameras.main.centerX;
+
+      // Header
+      this.add
+        .text(centerX, 30, 'Checkbox Component', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Left column: variations ---
+      const leftX = 180;
+      let y = 100;
+
+      const addSectionTitle = (text: string): void => {
+        this.add
+          .text(leftX, y, text, {
+            color: pw.color.slate(700),
+            fontFamily: 'Fredoka',
+            fontSize: '13px',
+          })
+          .setOrigin(0, 0.5);
+        y += 30;
+      };
+
+      addSectionTitle('Basic (default check icon)');
+      this.add.existing(
+        new Checkbox({
+          scene: this,
+          x: leftX + 15,
+          y,
+          label: 'Enable sound',
+          checked: true,
+        })
+      );
+      y += 45;
+
+      addSectionTitle('Custom icon (heart)');
+      this.add.existing(
+        new Checkbox({
+          scene: this,
+          x: leftX + 15,
+          y,
+          label: 'Favorite',
+          icon: 'heart',
+          color: 'red-500',
+        })
+      );
+      y += 45;
+
+      addSectionTitle('Star icon + purple');
+      this.add.existing(
+        new Checkbox({
+          scene: this,
+          x: leftX + 15,
+          y,
+          label: 'Rated',
+          icon: 'star',
+          color: 'purple-600',
+        })
+      );
+      y += 45;
+
+      addSectionTitle('Disabled (checked)');
+      this.add.existing(
+        new Checkbox({
+          scene: this,
+          x: leftX + 15,
+          y,
+          label: 'Locked feature',
+          checked: true,
+          disabled: true,
+        })
+      );
+      y += 45;
+
+      addSectionTitle('ReadOnly (click ignored, normal look)');
+      this.add.existing(
+        new Checkbox({
+          scene: this,
+          x: leftX + 15,
+          y,
+          label: 'Terms accepted',
+          checked: true,
+          readOnly: true,
+        })
+      );
+
+      // --- Right column: live form ---
+      const rightX = 500;
+      let ry = 100;
+
+      this.add
+        .text(rightX, ry, 'Mini form (getValue on submit)', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+      ry += 30;
+
+      const cbSound = new Checkbox({
+        scene: this,
+        x: rightX + 15,
+        y: ry,
+        label: 'Sound',
+        name: 'sound',
+        checked: true,
+        color: 'green-500',
+      });
+      this.add.existing(cbSound);
+      ry += 45;
+
+      const cbMusic = new Checkbox({
+        scene: this,
+        x: rightX + 15,
+        y: ry,
+        label: 'Music',
+        name: 'music',
+        color: 'green-500',
+      });
+      this.add.existing(cbMusic);
+      ry += 45;
+
+      const cbHaptics = new Checkbox({
+        scene: this,
+        x: rightX + 15,
+        y: ry,
+        label: 'Haptics',
+        name: 'haptics',
+        color: 'green-500',
+      });
+      this.add.existing(cbHaptics);
+      ry += 60;
+
+      const output = this.add
+        .text(rightX + 15, ry, '(click submit to log values)', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+      ry += 45;
+
+      const submitBtn = new TextButton({
+        scene: this,
+        x: rightX + 60,
+        y: ry,
+        text: 'Submit',
+        color: 'blue-500',
+        padding: '3',
+        onClick: () => {
+          const payload = {
+            sound: cbSound.getValue(),
+            music: cbMusic.getValue(),
+            haptics: cbHaptics.getValue(),
+          };
+          output.setText(JSON.stringify(payload));
+          console.log('form:', payload);
+        },
+      });
+      this.add.existing(submitBtn);
+
+      // Footer
+      this.add
+        .text(centerX, 590, 'Click any checkbox to see the pop animation.', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0.5, 0.5);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [CheckboxDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-checkbox-demo'] = game;
+      });
+    }
+  });
+</script>

--- a/packages/showcase/src/pages/hudini/dock.astro
+++ b/packages/showcase/src/pages/hudini/dock.astro
@@ -29,7 +29,7 @@ import PhaserGame from '../../components/PhaserGame.astro';
         <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
         <div class="bg-gray-50 rounded-lg p-4">
           <ul class="space-y-2 text-sm">
-            <li><code class="bg-gray-200 px-2 py-1 rounded">items</code> - <code>DockItem[]</code> where each item has <code>id</code>, <code>icon</code> and <code>label</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">items</code> - <code>DockItem[]</code> where each item has <code>id</code>, <code>icon</code> and an optional <code>label</code> (icon-only if omitted)</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">active</code> - Initial active item id (optional)</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">onSelect</code> - <code>(id, index) =&gt; void</code> callback fired on click</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">activeColor</code> / <code class="bg-gray-200 px-2 py-1 rounded">inactiveColor</code> - Icon/label colors per state</li>
@@ -53,7 +53,7 @@ import PhaserGame from '../../components/PhaserGame.astro';
     </div>
 
     <!-- Live Example -->
-    <PhaserGame width={800} height={520} />
+    <PhaserGame width={800} height={620} />
 
     <!-- Usage Example -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -210,6 +210,36 @@ class DockDemoScene extends Phaser.Scene {
         onSelect: (id) => bareDock.setActiveItem(id),
       });
       this.add.existing(bareDock);
+
+      // --- Dock C: icon-only variant ---
+      this.add
+        .text(centerX, 420, 'Icon-only variant (omit label)', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const iconOnlyDock = new Dock({
+        scene: this,
+        x: centerX,
+        y: 465,
+        active: 'play',
+        activeColor: 'emerald-600',
+        inactiveColor: 'slate-500',
+        gap: 24,
+        backgroundColor: 'slate-100',
+        borderRadius: 'full',
+        padding: '3',
+        items: [
+          { id: 'backward', icon: 'backward' },
+          { id: 'play', icon: 'play' },
+          { id: 'forward', icon: 'forward' },
+          { id: 'stop', icon: 'stop' },
+        ],
+        onSelect: (id) => iconOnlyDock.setActiveItem(id),
+      });
+      this.add.existing(iconOnlyDock);
     }
   }
 

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -106,6 +106,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Button component with icon support and customizable styling</p>
         </a>
 
+        <a href={getUrl('/hudini/alert')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">🚨</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Alert</h4>
+          </div>
+          <p class="text-sm text-gray-600">Semantic notification banner — success, error, warning, info, neutral</p>
+        </a>
+
         <a href={getUrl('/hudini/badge')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">🏷️</span>

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -122,6 +122,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Flat labeled box — panel titles, tags, status pills</p>
         </a>
 
+        <a href={getUrl('/hudini/checkbox')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">☑️</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Checkbox</h4>
+          </div>
+          <p class="text-sm text-gray-600">Toggleable form control with custom icon, disabled/readOnly, and a pop animation</p>
+        </a>
+
         <a href={getUrl('/hudini/circular-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">⭕</span>

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -138,6 +138,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Sliding switch with per-state icons that cross-fade — daisyUI-style</p>
         </a>
 
+        <a href={getUrl('/hudini/radio')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">🔘</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Radio</h4>
+          </div>
+          <p class="text-sm text-gray-600">Single-selection with a RadioGroup factory — layout-free grouping, custom icons per option</p>
+        </a>
+
         <a href={getUrl('/hudini/circular-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">⭕</span>

--- a/packages/showcase/src/pages/hudini/index.astro
+++ b/packages/showcase/src/pages/hudini/index.astro
@@ -130,6 +130,14 @@ const getUrl = (path: string) => {
           <p class="text-sm text-gray-600">Toggleable form control with custom icon, disabled/readOnly, and a pop animation</p>
         </a>
 
+        <a href={getUrl('/hudini/toggle')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
+          <div class="flex items-center mb-2">
+            <span class="text-2xl mr-3">🎚️</span>
+            <h4 class="font-semibold text-gray-900 group-hover:text-blue-600">Toggle</h4>
+          </div>
+          <p class="text-sm text-gray-600">Sliding switch with per-state icons that cross-fade — daisyUI-style</p>
+        </a>
+
         <a href={getUrl('/hudini/circular-progress')} class="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all">
           <div class="flex items-center mb-2">
             <span class="text-2xl mr-3">⭕</span>

--- a/packages/showcase/src/pages/hudini/radio.astro
+++ b/packages/showcase/src/pages/hudini/radio.astro
@@ -1,0 +1,395 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Radio + RadioGroup" description="Single-selection form control. RadioGroup manages the 'only one selected' invariant via a factory; individual Radios are free to be positioned anywhere in the scene.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Radio + RadioGroup</h2>
+      <p class="text-gray-600 mb-4">
+        Two components that work together. <strong>Radio</strong> is a single-selection form control — same contract as Checkbox (uncontrolled state, <code class="bg-gray-100 px-1 rounded">getValue()</code>, <code class="bg-gray-100 px-1 rounded">disabled</code>, <code class="bg-gray-100 px-1 rounded">readOnly</code>, custom icon), but click always <em>selects</em> and never deselects (matches native <code>&lt;input type="radio"&gt;</code>).
+      </p>
+      <p class="text-gray-600 mb-4">
+        <strong>RadioGroup</strong> is a stateless controller — no visual, just a factory. Call <code class="bg-gray-100 px-1 rounded">group.createRadio()</code> and place the returned Radios anywhere you want. The group enforces "only one selected" internally.
+      </p>
+      <p class="text-gray-600 mb-4 font-semibold text-blue-700">
+        Recommended: use <code class="bg-blue-50 px-1 rounded">RadioGroup</code> whenever you have 2+ related radios. Standalone Radio is supported but you own the "only one" logic manually.
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>🎯 <strong>Layout-free grouping</strong>: <code>createRadio()</code> returns a Radio you can drop anywhere — Stack, Card, scattered HUD positions</li>
+          <li>🔒 <strong>"Only one" invariant</strong> guaranteed by the group; no hidden global state, no scene-wide registry</li>
+          <li>💚 <strong>Custom icon</strong> per Radio (default <code>'circle'</code>, or use <code>'heart'</code>, <code>'star'</code>, <code>'skull'</code>, ...)</li>
+          <li>🎨 <strong>Group-level defaults</strong> (color, size, icon) inherited by every Radio, overridable per Radio</li>
+          <li>✨ <strong>Pop animation</strong> on the inner icon — scale + fade in with <code>Back.easeOut</code></li>
+          <li>📋 <strong>Form-ready</strong>: <code>group.getValue()</code> returns the selected string</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">RadioGroup props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">scene</code> - Phaser scene shared by all radios in the group</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">name</code> - Form field name, passed to <code>onChange</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">value</code> - Initially selected value</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">disabled</code>, <code class="bg-gray-200 px-2 py-1 rounded">readOnly</code> - Apply to every radio in the group</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">color</code>, <code class="bg-gray-200 px-2 py-1 rounded">icon</code>, <code class="bg-gray-200 px-2 py-1 rounded">iconColor</code>, <code class="bg-gray-200 px-2 py-1 rounded">size</code>, <code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code>, <code class="bg-gray-200 px-2 py-1 rounded">labelColor</code> - Defaults for every Radio created by this group</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onChange</code> - <code>(value, name?) =&gt; void</code></li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Methods -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">RadioGroup methods</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">createRadio(params)</code> - Factory. Same params as Radio, but the group manages <code>checked</code> and <code>onChange</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">setValue(v)</code> / <code class="bg-gray-200 px-2 py-1 rounded">getValue()</code> - Programmatic selection</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">disable()</code> / <code class="bg-gray-200 px-2 py-1 rounded">enable()</code> / <code class="bg-gray-200 px-2 py-1 rounded">setDisabled(v)</code> / <code class="bg-gray-200 px-2 py-1 rounded">isDisabled()</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">setReadOnly(v)</code> / <code class="bg-gray-200 px-2 py-1 rounded">isReadOnly()</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onChange(cb)</code> - Replace the callback</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">destroy()</code> - Clear the group's registry (does not destroy the Radios themselves)</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={720} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    RadioGroup,
+    Stack,
+} from 'hudini';
+
+class DifficultyScene extends Phaser.Scene {
+    create(): void {
+        // 1. Create the group first — no visual.
+        const group = new RadioGroup({
+            scene: this,
+            name: 'difficulty',
+            value: 'normal',
+            color: 'blue-500',
+            onChange: (value) => {
+                console.log('selected:', value);
+            },
+        });
+
+        // 2. Create Radios via the factory. Place them anywhere.
+        const easy   = group.createRadio({ x: 0, y: 0, value: 'easy',   label: 'Easy' });
+        const normal = group.createRadio({ x: 0, y: 0, value: 'normal', label: 'Normal' });
+        const hard   = group.createRadio({ x: 0, y: 0, value: 'hard',   label: 'Hard' });
+
+        // 3. Lay them out — Stack (or wherever you want).
+        const layout = new Stack({
+            scene: this, x: 400, y: 300,
+            direction: 'column',
+            gap: 12,
+            children: [easy, normal, hard],
+        });
+        this.add.existing(layout);
+
+        // Read the current value later (form-style):
+        console.log(group.getValue()); // 'normal'
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Radio,
+    RadioGroup,
+    Stack,
+    TextButton,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class RadioDemoScene extends Phaser.Scene {
+    constructor() {
+      super('radio-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(200));
+
+      const centerX = this.cameras.main.centerX;
+
+      // Header
+      this.add
+        .text(centerX, 30, 'Radio + RadioGroup', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Section 1: difficulty group in a Stack ---
+      this.add
+        .text(180, 90, "Difficulty — group in a column Stack", {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+
+      const diffCurrent = this.add
+        .text(180, 118, 'selected: normal', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0, 0.5);
+
+      const diffGroup = new RadioGroup({
+        scene: this,
+        name: 'difficulty',
+        value: 'normal',
+        color: 'blue-500',
+        onChange: (value) => {
+          diffCurrent.setText(`selected: ${value ?? '(none)'}`);
+        },
+      });
+
+      const diffStack = new Stack({
+        scene: this,
+        x: 220,
+        y: 210,
+        direction: 'column',
+        gap: 12,
+        align: 'left',
+        children: [
+          diffGroup.createRadio({ x: 0, y: 0, value: 'easy',   label: 'Easy' }),
+          diffGroup.createRadio({ x: 0, y: 0, value: 'normal', label: 'Normal' }),
+          diffGroup.createRadio({ x: 0, y: 0, value: 'hard',   label: 'Hard' }),
+        ],
+      });
+      this.add.existing(diffStack);
+
+      // --- Section 2: custom icon per Radio (heart / star / skull) ---
+      this.add
+        .text(500, 90, 'Custom icon per Radio', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+
+      const flavorCurrent = this.add
+        .text(500, 118, 'selected: (none)', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0, 0.5);
+
+      const flavorGroup = new RadioGroup({
+        scene: this,
+        name: 'flavor',
+        color: 'red-500',
+        onChange: (value) => {
+          flavorCurrent.setText(`selected: ${value ?? '(none)'}`);
+        },
+      });
+
+      const flavorStack = new Stack({
+        scene: this,
+        x: 550,
+        y: 210,
+        direction: 'column',
+        gap: 12,
+        align: 'left',
+        children: [
+          flavorGroup.createRadio({
+            x: 0, y: 0, value: 'love', label: 'Love',
+            icon: 'heart', color: 'red-500', iconSize: 12,
+          }),
+          flavorGroup.createRadio({
+            x: 0, y: 0, value: 'star', label: 'Star',
+            icon: 'star', color: 'amber-500', iconSize: 12,
+          }),
+          flavorGroup.createRadio({
+            x: 0, y: 0, value: 'danger', label: 'Danger',
+            icon: 'skull', color: 'slate-800', iconSize: 12,
+          }),
+        ],
+      });
+      this.add.existing(flavorStack);
+
+      // --- Section 3: scattered layout (radios placed at arbitrary positions) ---
+      this.add
+        .text(centerX, 335, 'Scattered layout — radios positioned freely', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const scatteredCurrent = this.add
+        .text(centerX, 358, 'selected: (none)', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const scatteredGroup = new RadioGroup({
+        scene: this,
+        name: 'position',
+        color: 'purple-600',
+        onChange: (value) => {
+          scatteredCurrent.setText(`selected: ${value ?? '(none)'}`);
+        },
+      });
+
+      // Each Radio in its own place — no Stack, no options array.
+      this.add.existing(
+        scatteredGroup.createRadio({
+          x: 200,
+          y: 410,
+          value: 'top-left',
+          label: 'Top left',
+        })
+      );
+      this.add.existing(
+        scatteredGroup.createRadio({
+          x: 500,
+          y: 410,
+          value: 'top-right',
+          label: 'Top right',
+        })
+      );
+      this.add.existing(
+        scatteredGroup.createRadio({
+          x: 200,
+          y: 460,
+          value: 'bottom-left',
+          label: 'Bottom left',
+        })
+      );
+      this.add.existing(
+        scatteredGroup.createRadio({
+          x: 500,
+          y: 460,
+          value: 'bottom-right',
+          label: 'Bottom right',
+        })
+      );
+
+      // --- Section 4: mini form ---
+      this.add
+        .text(centerX, 530, 'Mini form (getValue on submit)', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const formOutput = this.add
+        .text(centerX, 685, '(click submit to log values)', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      const submitBtn = new TextButton({
+        scene: this,
+        x: centerX,
+        y: 640,
+        text: 'Submit',
+        color: 'blue-500',
+        padding: '3',
+        onClick: () => {
+          const payload = {
+            difficulty: diffGroup.getValue(),
+            flavor: flavorGroup.getValue(),
+            position: scatteredGroup.getValue(),
+          };
+          formOutput.setText(JSON.stringify(payload));
+          console.log('form:', payload);
+        },
+      });
+      this.add.existing(submitBtn);
+
+      // --- Section 5: standalone Radio (rare — not managed by a group) ---
+      this.add
+        .text(centerX, 560, 'Standalone Radio (no group — manual state):', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      this.add.existing(
+        new Radio({
+          scene: this,
+          x: centerX,
+          y: 590,
+          label: 'I agree to the terms',
+          value: 'terms',
+          color: 'emerald-600',
+          onChange: (checked, value) => {
+            console.log('standalone:', value, checked);
+          },
+        })
+      );
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [RadioDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-radio-demo'] = game;
+      });
+    }
+  });
+</script>

--- a/packages/showcase/src/pages/hudini/text-button.astro
+++ b/packages/showcase/src/pages/hudini/text-button.astro
@@ -37,13 +37,15 @@ import PhaserGame from '../../components/PhaserGame.astro';
             <li><code class="bg-gray-200 px-2 py-1 rounded">padding</code> - Internal padding using spacing tokens</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">fontSize</code> - Text size using typography tokens</li>
             <li><code class="bg-gray-200 px-2 py-1 rounded">variant</code> - <code>'filled'</code> (default) or <code>'outline'</code> — daisyUI-style visual variants</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">leftIcon</code> / <code class="bg-gray-200 px-2 py-1 rounded">rightIcon</code> - Optional Font Awesome icons (IconKey) shown on either side of the text</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">iconGap</code> - Space between icon and text (defaults to ~35% of the font size)</li>
           </ul>
         </div>
       </div>
     </div>
 
     <!-- Live Example -->
-    <PhaserGame width={800} height={720} />
+    <PhaserGame width={800} height={860} />
 
     <!-- Usage Example -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -110,6 +112,17 @@ class ButtonDemoScene extends Phaser.Scene {
             variant: 'outline',
         });
         this.add.existing(outlineButton);
+
+        // Button with a left icon — < home > Home
+        const homeButton = new TextButton({
+            scene: this,
+            x: this.cameras.main.centerX,
+            y: this.cameras.main.centerY + 210,
+            text: 'Home',
+            color: 'blue-500',
+            leftIcon: 'house',
+        });
+        this.add.existing(homeButton);
     }
 }`}</code></pre>
       </div>
@@ -119,6 +132,7 @@ class ButtonDemoScene extends Phaser.Scene {
 
 <script>
   import Phaser, { Scene } from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
   import {
     loadFonts,
     type RadiusKey,
@@ -222,6 +236,52 @@ class ButtonDemoScene extends Phaser.Scene {
         this.buttons.push(outline);
       });
 
+      // --- With Icons section ---
+      const iconRowY = startY + buttonConfigs.length * rowSpacing + 20;
+
+      this.add.text(centerX, iconRowY, 'With Icons (leftIcon / rightIcon)', {
+        color: pw.color.slate(300),
+        fontFamily: 'Fredoka',
+        fontSize: '20px',
+      }).setOrigin(0.5, 0.5);
+
+      const iconExamples: {
+        text: string;
+        color: string;
+        leftIcon?: string;
+        rightIcon?: string;
+        variant?: 'filled' | 'outline';
+      }[] = [
+        { text: 'Home', color: 'blue-500', leftIcon: 'house' },
+        { text: 'Next', color: 'green-500', rightIcon: 'arrow-right' },
+        { text: 'Search', color: 'purple-500', leftIcon: 'magnifying-glass' },
+        { text: 'Save', color: 'emerald-500', leftIcon: 'floppy-disk', rightIcon: 'check' },
+        { text: 'Delete', color: 'red-500', leftIcon: 'trash', variant: 'outline' },
+        { text: 'Star', color: 'yellow-500', leftIcon: 'star', rightIcon: 'star', variant: 'outline' },
+      ];
+
+      const iconBaseY = iconRowY + 45;
+      iconExamples.forEach((ex, i) => {
+        const col = i % 3;
+        const row = Math.floor(i / 3);
+        const x = width * (0.25 + col * 0.25);
+        const y = iconBaseY + row * 65;
+        const btn = new TextButton({
+          scene: this,
+          x,
+          y,
+          text: ex.text,
+          color: ex.color,
+          borderRadius: 'md',
+          padding: '4',
+          ...(ex.leftIcon && { leftIcon: ex.leftIcon as never }),
+          ...(ex.rightIcon && { rightIcon: ex.rightIcon as never }),
+          ...(ex.variant && { variant: ex.variant }),
+        });
+        this.add.existing(btn);
+        this.buttons.push(btn);
+      });
+
       // Add instructions
       this.add.text(centerX, this.cameras.main.height - 30, 'Click and hover over the buttons to see interactions', {
         color: pw.color.slate(400),
@@ -236,7 +296,7 @@ class ButtonDemoScene extends Phaser.Scene {
   document.addEventListener('DOMContentLoaded', () => {
     const gameConfig = (window as any).gameContainer;
     if (gameConfig) {
-      loadFonts().then(() => {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
         const game = new Phaser.Game({
           ...gameConfig,
           scene: [TextButtonDemoScene],

--- a/packages/showcase/src/pages/hudini/toggle.astro
+++ b/packages/showcase/src/pages/hudini/toggle.astro
@@ -1,0 +1,343 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import PhaserGame from '../../components/PhaserGame.astro';
+---
+
+<Layout title="Hudini Toggle Component" description="daisyUI-style switch — pill-shaped track + sliding handle with per-state icons that cross-fade.">
+  <div class="space-y-8">
+    <!-- Description -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Toggle Component</h2>
+      <p class="text-gray-600 mb-4">
+        A daisyUI-style switch. Same contract as <a href="/hudini/checkbox" class="text-blue-600 hover:underline">Checkbox</a> — uncontrolled state, <code class="bg-gray-100 px-1 rounded">onChange</code> callback, <code class="bg-gray-100 px-1 rounded">disabled</code>/<code class="bg-gray-100 px-1 rounded">readOnly</code>, <code class="bg-gray-100 px-1 rounded">getValue()</code> for form serialization. The visual is a pill-shaped track with a handle that slides between left (off) and right (on).
+      </p>
+      <p class="text-gray-600 mb-4">
+        Two icons — <code class="bg-gray-100 px-1 rounded">onIcon</code> and <code class="bg-gray-100 px-1 rounded">offIcon</code> — ride inside the handle. When the toggle flips, the handle slides while the icons cross-fade (outgoing → 0, incoming → 1).
+      </p>
+
+      <!-- Features -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Features</h3>
+        <ul class="list-disc list-inside space-y-1 text-gray-600">
+          <li>🎯 <strong>Same API as Checkbox</strong>: <code>toggle</code>, <code>setChecked</code>, <code>getValue</code>, <code>disable</code>, <code>readOnly</code>, <code>onChange</code>, <code>onClick</code>, <code>name</code></li>
+          <li>🎨 <strong>Two icons</strong>: <code>onIcon</code> (default <code>'check'</code>) + <code>offIcon</code> (default <code>'xmark'</code>). Pass <code>null</code> to disable either</li>
+          <li>💫 <strong>Cross-fade during slide</strong>: outgoing icon fades to 0 while incoming fades to 1, all in sync with the handle motion</li>
+          <li>🖌️ <strong>Two track colors</strong>: <code>color</code> (on) + <code>offColor</code> (off) — perfect for dark-mode toggles etc.</li>
+          <li>🧱 <strong>Composable</strong>: reports its size so Row / Column / Stack lay it out correctly</li>
+        </ul>
+      </div>
+
+      <!-- Props -->
+      <div class="mb-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-3">Props</h3>
+        <div class="bg-gray-50 rounded-lg p-4">
+          <ul class="space-y-2 text-sm">
+            <li><code class="bg-gray-200 px-2 py-1 rounded">checked</code> - Initial state (default <code>false</code>)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">label</code> - Optional text to the right</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onIcon</code> / <code class="bg-gray-200 px-2 py-1 rounded">offIcon</code> - FA icon per state. Pass <code>null</code> to disable</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">iconColor</code> - Default <code>'slate-700'</code> (contrast on white handle)</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">color</code> / <code class="bg-gray-200 px-2 py-1 rounded">offColor</code> - Track color per state</li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">handleColor</code> - Default <code>'white'</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">labelColor</code>, <code class="bg-gray-200 px-2 py-1 rounded">size</code>, <code class="bg-gray-200 px-2 py-1 rounded">borderRadius</code>, <code class="bg-gray-200 px-2 py-1 rounded">labelGap</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">disabled</code>, <code class="bg-gray-200 px-2 py-1 rounded">readOnly</code>, <code class="bg-gray-200 px-2 py-1 rounded">name</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onChange</code> - <code>(checked, name?) =&gt; void</code></li>
+            <li><code class="bg-gray-200 px-2 py-1 rounded">onClick</code> - Fires on any click</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Live Example -->
+    <PhaserGame width={800} height={620} />
+
+    <!-- Usage Example -->
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 class="text-lg font-semibold text-gray-900 mb-3">Usage Example</h3>
+      <div class="bg-gray-900 rounded-lg p-4 overflow-x-auto">
+        <pre class="text-sm text-gray-100"><code>{`import Phaser from 'phaser';
+import {
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Toggle,
+} from 'hudini';
+
+class SettingsScene extends Phaser.Scene {
+    create(): void {
+        // 1. Default toggle — check / xmark icons that cross-fade
+        const sound = new Toggle({
+            scene: this, x: 200, y: 100,
+            label: 'Sound',
+            checked: true,
+            name: 'sound',
+            onChange: (v) => console.log('sound:', v),
+        });
+
+        // 2. Dark-mode toggle — moon (on) + sun (off), different track colors
+        const darkMode = new Toggle({
+            scene: this, x: 200, y: 160,
+            label: 'Dark mode',
+            onIcon: 'moon',
+            offIcon: 'sun',
+            color: 'indigo-600',
+            offColor: 'yellow-400',
+        });
+
+        // 3. Read the current values later (form-style)
+        const submit = () => ({
+            sound: sound.getValue(),
+            dark: darkMode.getValue(),
+        });
+    }
+}`}</code></pre>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import Phaser from 'phaser';
+  import { loadFont } from 'font-awesome-for-phaser';
+  import {
+    loadFonts,
+    createTheme,
+    HUDINI_KEY,
+    HudiniPlugin,
+    withHudini,
+    Toggle,
+    TextButton,
+  } from 'hudini';
+
+  const theme = createTheme({});
+  type Theme = typeof theme;
+
+  class ToggleDemoScene extends Phaser.Scene {
+    constructor() {
+      super('toggle-demo');
+    }
+
+    create(): void {
+      const { pw } = withHudini<Theme>(this);
+      this.cameras.main.setBackgroundColor(pw.color.slate(200));
+
+      const centerX = this.cameras.main.centerX;
+
+      this.add
+        .text(centerX, 30, 'Toggle Component', {
+          color: pw.color.slate(900),
+          fontFamily: 'Fredoka',
+          fontSize: '28px',
+        })
+        .setOrigin(0.5, 0.5);
+
+      // --- Left column: variations ---
+      const leftX = 180;
+      let y = 100;
+
+      const addSectionTitle = (text: string): void => {
+        this.add
+          .text(leftX, y, text, {
+            color: pw.color.slate(700),
+            fontFamily: 'Fredoka',
+            fontSize: '13px',
+          })
+          .setOrigin(0, 0.5);
+        y += 30;
+      };
+
+      addSectionTitle('Default (check / xmark)');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Enable sound',
+          checked: true,
+        })
+      );
+      y += 55;
+
+      addSectionTitle('Dark mode (moon / sun)');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Dark mode',
+          onIcon: 'moon',
+          offIcon: 'sun',
+          color: 'indigo-600',
+          offColor: 'yellow-400',
+        })
+      );
+      y += 55;
+
+      addSectionTitle('Volume (volume-high / volume-xmark)');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Ambient audio',
+          onIcon: 'volume-high',
+          offIcon: 'volume-xmark',
+          color: 'cyan-600',
+          checked: true,
+        })
+      );
+      y += 55;
+
+      addSectionTitle('Notifications (bell / bell-slash)');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Push notifications',
+          onIcon: 'bell',
+          offIcon: 'bell-slash',
+          color: 'amber-500',
+        })
+      );
+      y += 55;
+
+      addSectionTitle('No icons (bare switch)');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Beta features',
+          onIcon: null,
+          offIcon: null,
+          color: 'emerald-500',
+        })
+      );
+      y += 55;
+
+      addSectionTitle('Disabled');
+      this.add.existing(
+        new Toggle({
+          scene: this,
+          x: leftX + 25,
+          y,
+          label: 'Locked feature',
+          checked: true,
+          disabled: true,
+        })
+      );
+
+      // --- Right column: live form ---
+      const rightX = 500;
+      let ry = 100;
+
+      this.add
+        .text(rightX, ry, 'Mini settings panel (getValue on submit)', {
+          color: pw.color.slate(700),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+      ry += 30;
+
+      const tSound = new Toggle({
+        scene: this,
+        x: rightX + 25,
+        y: ry,
+        label: 'Sound',
+        name: 'sound',
+        checked: true,
+        color: 'green-500',
+      });
+      this.add.existing(tSound);
+      ry += 50;
+
+      const tMusic = new Toggle({
+        scene: this,
+        x: rightX + 25,
+        y: ry,
+        label: 'Music',
+        name: 'music',
+        color: 'green-500',
+      });
+      this.add.existing(tMusic);
+      ry += 50;
+
+      const tHaptics = new Toggle({
+        scene: this,
+        x: rightX + 25,
+        y: ry,
+        label: 'Haptics',
+        name: 'haptics',
+        color: 'green-500',
+      });
+      this.add.existing(tHaptics);
+      ry += 55;
+
+      const output = this.add
+        .text(rightX + 15, ry, '(click submit to log values)', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '13px',
+        })
+        .setOrigin(0, 0.5);
+      ry += 45;
+
+      const submitBtn = new TextButton({
+        scene: this,
+        x: rightX + 60,
+        y: ry,
+        text: 'Submit',
+        color: 'blue-500',
+        padding: '3',
+        onClick: () => {
+          const payload = {
+            sound: tSound.getValue(),
+            music: tMusic.getValue(),
+            haptics: tHaptics.getValue(),
+          };
+          output.setText(JSON.stringify(payload));
+          console.log('settings:', payload);
+        },
+      });
+      this.add.existing(submitBtn);
+
+      // Footer
+      this.add
+        .text(centerX, 590, 'Click any toggle — the handle slides while the icons cross-fade.', {
+          color: pw.color.slate(600),
+          fontFamily: 'Fredoka',
+          fontSize: '12px',
+        })
+        .setOrigin(0.5, 0.5);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const gameConfig = (window as any).gameContainer;
+    if (gameConfig) {
+      Promise.all([loadFonts(), loadFont()]).then(() => {
+        const game = new Phaser.Game({
+          ...gameConfig,
+          scene: [ToggleDemoScene],
+          plugins: {
+            global: [
+              {
+                key: HUDINI_KEY,
+                plugin: HudiniPlugin,
+                mapping: HUDINI_KEY,
+                data: { theme },
+              },
+            ],
+          },
+        });
+
+        if (!(window as any).__phaserGames) {
+          (window as any).__phaserGames = {};
+        }
+        (window as any).__phaserGames['hudini-toggle-demo'] = game;
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
## Description

Big content push for Hudini — 8 new components filling out the daisyUI-flavored kit, plus icon support in TextButton and the outline variant on TextButton/IconButton. Everything follows the same architectural patterns established in earlier PRs: uncontrolled state, callback-based communication, no hidden global stores, layout-free composition.

**New components**: `Stack`, `Dock`, `Alert`, `Checkbox`, `Toggle`, `Radio`, `RadioGroup`.

**Additions to existing**: outline variant on TextButton/IconButton, `leftIcon`/`rightIcon` on TextButton, optional labels on Dock items.

## Type of Change

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (changes to documentation only)
- [ ] 🎨 Style (formatting, missing semicolons, etc; no code changes)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance (change that improves performance)
- [x] ✅ Test (adding missing tests or correcting existing tests)
- [ ] 🔧 Chore (changes to the build process or auxiliary tools)

## Affected Packages

- [ ] font-awesome-for-phaser
- [ ] phaser-hooks
- [ ] phaser-wind
- [x] hudini
- [ ] phaser-sound-studio
- [ ] phaser-data-studio
- [x] showcase
- [ ] virtual-joystick
- [ ] Other (please specify): ______

## Changes

### Added

**Layout primitives**

- **`Stack`** — Row/Column with optional `backgroundColor` / `padding` / `borderRadius`. When a background is requested, Stack composes a `Card` behind the children (fixing a latent Card bug where explicit `width`/`height` were ignored during initial texture generation because `ContainerInteractive`'s getter proxied through an unset `hitArea`). Exposes `layoutContainer` (inner Row/Column) and `background` (Card or `null`).

**Navigation**

- **`Dock`** — daisyUI-style bottom-navigation. Accepts `items: DockItem[]` (`{ id, icon, label? }`), an optional `active` id, and `onSelect(id, index)`. Stateless — client controls the visual active state via `setActiveItem`. Labels are optional per item (icon-only docks supported for minimal toolbars).

**Notification / form primitives**

- **`Alert`** — static banner with semantic variants (`success` / `error` / `warning` / `info` / `neutral`). Each variant has a default color and default left icon (`circle-check`, `circle-xmark`, `triangle-exclamation`, `circle-info`). Same visual language as a filled TextButton. Optional `onClick`. Content component only — Toast (auto-dismiss + timing) is deferred to a future PR.
- **`Checkbox`** — uncontrolled form control. Same contract every subsequent form field will use: `checked` / `onChange` / `toggle` / `setChecked` / `getValue` / `disable` / `enable` / `setDisabled` / `setReadOnly` / `isReadOnly` / `onClick`. Custom icon (default `check`), custom color, optional label (clicking the label toggles too). Pop-in / fade-out animation on the icon (`Back.easeOut` in, `Sine.easeIn` out).
- **`Toggle`** — daisyUI-style switch. Same contract as Checkbox. Pill-shaped track + sliding handle. Two icons (`onIcon` default `check`, `offIcon` default `xmark`) that cross-fade while the handle slides. Separate track colors for on/off state.
- **`Radio`** — single-selection form control. Same contract as Checkbox with one semantic difference: **click always selects, never deselects** (matches native `<input type=\"radio\">`). Custom icon (default `circle`), configurable `iconSize` (default ~55% of size, renders as a small centered dot).
- **`RadioGroup`** — controller with a factory pattern, not a visual component. Exposes `group.createRadio({ x, y, value, ... })` that returns a `Radio` wired to the group. The group enforces the \"only one selected\" invariant via an internal update-lock (prevents recursion when siblings are deselected). No hidden global state, no name-based auto-linking. Radios can be placed anywhere in the scene (Stack, scattered HUD positions, wherever) — the group doesn't dictate layout.

**Button enhancements**

- **Outline variant** on `TextButton` and `IconButton` — daisyUI-style transparent bg + colored border + colored glyph. `variant: 'filled' | 'outline'` + `setVariant()` runtime setter. Outline border is drawn inset by half its thickness so `.width` / `.height` still report the visual box for Row/Column/Stack measurement. Added `BUTTON_OUTLINE_THICKNESS` constant to `utils/button-style`.
- **`leftIcon` / `rightIcon` / `iconGap`** on `TextButton` — optional Font Awesome icons on either side of the text (e.g. `<home icon> Home` or `Next <arrow-right>`). Icons inherit the button's color/stroke rules per variant. Content is composed via a horizontal `Stack` for correct measurement.
- **`label` on `DockItem` is now optional** — icon-only Dock variants supported (e.g. media-player-style playback controls).

### Changed

- **`Card`** — cached explicit dimensions in `explicitWidth` / `explicitHeight` private fields so the initial `createBackgroundTexture` call can read them BEFORE `hitArea` is wired. Previously, passing `width`/`height` produced a 0×0 texture because `ContainerInteractive`'s `.width` getter returned 0 pre-hitArea. This unblocked `Stack`'s background composition.
- **`TextButton`** — content is now composed via a horizontal `Stack` (`contentStack`), enabling icon + text layout. `regenerateSprites` also calls `contentStack.layout()`. `getButtonDimensions` reads from `contentStack.width/height + padding * 2` instead of the raw text bounds.
- **Extracted shared button styling** into `utils/button-style.ts` — `BUTTON_STROKE_THICKNESS`, `BUTTON_OUTLINE_THICKNESS`, `ButtonVariant`, `getButtonStrokeColor`. Reused across TextButton, IconButton, Badge, Alert.

### Removed

- None.

## How to Test

1. **Unit tests** — `pnpm --filter hudini test` should show **106 tests passing** (test count nearly doubled from adding the 6 new components). The pre-existing `card.spec.ts` collection failure due to `SceneWithPhaserWind`'s deprecated `Phaser.Scene` global is unrelated to this PR.
2. **Typecheck** — `pnpm --filter hudini tsc --noEmit` should be clean.
3. **Lint** — `pnpm --filter hudini lint` should be clean.
4. **Showcase build** — `pnpm --filter phaser-toolkit-showcase build` should generate **34 pages** without errors.
5. **Visual verification** — open the showcase locally:
   - `/hudini/stack` — 4 sections (Row no-bg, Row with bg, Column with bg, nested Stacks).
   - `/hudini/dock` — bottom dock updating a \"Current selection\" label + a bare (no bg) dock + an icon-only playback dock.
   - `/hudini/alert` — 5 semantic variants with defaults + icon overrides + a click-to-dismiss demo.
   - `/hudini/checkbox` — 5 variations (default check, heart, star, disabled, readOnly) + a mini form with getValue-on-submit.
   - `/hudini/toggle` — 6 variations (default, dark-mode moon/sun, volume, notifications, no-icons, disabled) + a settings-panel mini form.
   - `/hudini/radio` — a difficulty group in a Stack, custom icon per Radio (heart/star/skull), a scattered layout demo (radios placed at arbitrary x/y proving the layout-free grouping), a standalone Radio, and a mini form aggregating three groups.
   - `/hudini/text-button` — Filled | Outline side-by-side comparison + a \"With Icons\" section (`<home icon> Home`, `Next <arrow-right>`, `Save` with left+right icons, outline variants with icons).
   - `/hudini/icon-button` — new \"Outline Variant\" row.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset to document this change (`pnpm changeset`)